### PR TITLE
Issue#9/candle chart option

### DIFF
--- a/client/components/CandleChart.tsx
+++ b/client/components/CandleChart.tsx
@@ -1,10 +1,6 @@
 import * as React from 'react'
-import { CandleData, ChartOption, ChartRenderOption } from '@/types/ChartTypes'
+import { CandleData, ChartRenderOption } from '@/types/ChartTypes'
 import * as d3 from 'd3'
-import {
-  DEFAULT_CANDLER_CHART_RENDER_OPTION,
-  DEFAULT_CANDLE_CHART_OPTION
-} from '@/constants/ChartConstants'
 import { D3ZoomEvent } from 'd3'
 const CHART_CONTAINER_X_SIZE = 1000
 const CHART_CONTAINER_Y_SIZE = 800
@@ -16,10 +12,10 @@ function makeDate(timestamp: number, period: number): Date {
   return new Date(timestamp - (timestamp % (period * 1000)))
 }
 function calculateCandlewidth(
-  renderOptions: ChartRenderOption,
+  option: ChartRenderOption,
   chartXSize: number
 ): number {
-  return chartXSize / renderOptions.renderCandleCount
+  return chartXSize / option.renderCandleCount
 }
 function getYAxisScale(data: CandleData[]) {
   const [min, max] = [
@@ -33,17 +29,16 @@ function getYAxisScale(data: CandleData[]) {
   }
   return d3.scaleLinear().domain([min, max]).range([CHART_AREA_Y_SIZE, 0])
 }
-function getXAxisScale(renderOpt: ChartRenderOption, data: CandleData[]) {
+function getXAxisScale(option: ChartRenderOption, data: CandleData[]) {
   return d3
     .scaleTime()
     .domain([
       //데이터는 End가 최신 데이터이기 때문에, 순서를 반대로 해야 시간순서대로 들어온다?
       makeDate(
-        data[renderOpt.renderStartDataIndex + renderOpt.renderCandleCount]
-          .timestamp,
+        data[option.renderStartDataIndex + option.renderCandleCount].timestamp,
         60
       ),
-      makeDate(data[renderOpt.renderStartDataIndex].timestamp, 60)
+      makeDate(data[option.renderStartDataIndex].timestamp, 60)
     ]) //옵션화 필요함
     .range([0, CHART_AREA_X_SIZE])
     .nice()
@@ -51,28 +46,27 @@ function getXAxisScale(renderOpt: ChartRenderOption, data: CandleData[]) {
 function updateChart(
   svgRef: React.RefObject<SVGSVGElement>,
   data: CandleData[],
-  renderOpt: ChartRenderOption,
-  options: ChartOption
+  option: ChartRenderOption
 ) {
-  const candleWidth = calculateCandlewidth(renderOpt, CHART_AREA_X_SIZE)
+  const candleWidth = calculateCandlewidth(option, CHART_AREA_X_SIZE)
   const chartContainer = d3.select(svgRef.current)
   const chartArea = chartContainer.select('svg#chart-area')
   console.log(
     '범위',
-    renderOpt.renderStartDataIndex,
-    renderOpt.renderStartDataIndex + renderOpt.renderCandleCount
+    option.renderStartDataIndex,
+    option.renderStartDataIndex + option.renderCandleCount
   )
   const yAxisScale = getYAxisScale(
     data.slice(
-      renderOpt.renderStartDataIndex,
-      renderOpt.renderStartDataIndex + renderOpt.renderCandleCount
+      option.renderStartDataIndex,
+      option.renderStartDataIndex + option.renderCandleCount
     )
   )
   if (!yAxisScale) {
     console.error('받아온 API 데이터 에러')
     return undefined
   }
-  const xAxisScale = getXAxisScale(renderOpt, data)
+  const xAxisScale = getXAxisScale(option, data)
   chartContainer
     .select<SVGSVGElement>('g#y-axis')
     .attr('transform', `translate(${CHART_AREA_X_SIZE},0)`)
@@ -160,14 +154,15 @@ function updateChart(
 }
 interface CandleChartProps {
   candleData: CandleData[]
-  option: ChartOption
+  option: ChartRenderOption
+  optionSetter: React.Dispatch<React.SetStateAction<ChartRenderOption>>
 }
 
 function initChart(
   svgRef: React.RefObject<SVGSVGElement>,
   data: CandleData[],
-  renderOpt: ChartRenderOption,
-  CandleMetaDataSetter: React.Dispatch<React.SetStateAction<ChartRenderOption>>
+  option: ChartRenderOption,
+  optionSetter: React.Dispatch<React.SetStateAction<ChartRenderOption>>
 ) {
   const chartContainer = d3.select(svgRef.current)
   chartContainer.attr('width', CHART_CONTAINER_X_SIZE)
@@ -176,18 +171,18 @@ function initChart(
   chartArea.attr('width', CHART_AREA_X_SIZE)
   chartArea.attr('height', CHART_AREA_Y_SIZE)
   chartArea.attr('view')
-  console.error(renderOpt.renderStartDataIndex, renderOpt.renderCandleCount)
+  console.error(option.renderStartDataIndex, option.renderCandleCount)
   const yAxisScale = getYAxisScale(
     data.slice(
-      renderOpt.renderStartDataIndex,
-      renderOpt.renderStartDataIndex + renderOpt.renderCandleCount
+      option.renderStartDataIndex,
+      option.renderStartDataIndex + option.renderCandleCount
     )
   )
   if (!yAxisScale) {
     console.error('받아온 API 데이터 에러')
     return undefined
   }
-  const xAxisScale = getXAxisScale(renderOpt, data)
+  const xAxisScale = getXAxisScale(option, data)
   chartContainer
     .select<SVGSVGElement>('g#y-axis')
     .attr('transform', `translate(${CHART_AREA_X_SIZE},0)`)
@@ -207,7 +202,7 @@ function initChart(
     ])
     .on('zoom', function (event: D3ZoomEvent<SVGSVGElement, CandleData>) {
       transalateX = event.transform.x
-      CandleMetaDataSetter((prev: ChartRenderOption) => {
+      optionSetter((prev: ChartRenderOption) => {
         movedCandle = Math.floor(
           transalateX / calculateCandlewidth(prev, CHART_AREA_X_SIZE)
         )
@@ -223,7 +218,7 @@ function initChart(
   d3.select<SVGSVGElement, CandleData>('#chart-container')
     .call(zoom)
     .on('wheel', (e: WheelEvent) => {
-      CandleMetaDataSetter(prev => {
+      optionSetter(prev => {
         return {
           ...prev,
           renderCandleCount: prev.renderCandleCount + (e.deltaY > 0 ? 1 : -1)
@@ -234,20 +229,13 @@ function initChart(
 
 export const CandleChart: React.FunctionComponent<CandleChartProps> = props => {
   const chartSvg = React.useRef<SVGSVGElement>(null)
-  const [chartRenderOption, setRenderOption] =
-    React.useState<ChartRenderOption>(DEFAULT_CANDLER_CHART_RENDER_OPTION)
   React.useEffect(() => {
-    initChart(chartSvg, props.candleData, chartRenderOption, setRenderOption)
+    initChart(chartSvg, props.candleData, props.option, props.optionSetter)
   }, [])
 
   React.useEffect(() => {
-    updateChart(
-      chartSvg,
-      props.candleData,
-      chartRenderOption,
-      DEFAULT_CANDLE_CHART_OPTION
-    )
-  }, [props.candleData, chartRenderOption])
+    updateChart(chartSvg, props.candleData, props.option)
+  }, [props.candleData, props.option])
 
   return (
     <div id="chart">

--- a/client/components/CandleChart.tsx
+++ b/client/components/CandleChart.tsx
@@ -2,47 +2,18 @@ import * as React from 'react'
 import { CandleData, ChartRenderOption } from '@/types/ChartTypes'
 import * as d3 from 'd3'
 import { D3ZoomEvent } from 'd3'
-const CHART_CONTAINER_X_SIZE = 1000
-const CHART_CONTAINER_Y_SIZE = 800
-const X_RIGHT_MARGIN = 100
-const Y_RIGHT_MARGIN = 100
-const CHART_AREA_X_SIZE = CHART_CONTAINER_X_SIZE - X_RIGHT_MARGIN
-const CHART_AREA_Y_SIZE = CHART_CONTAINER_Y_SIZE - Y_RIGHT_MARGIN
-function makeDate(timestamp: number, period: number): Date {
-  return new Date(timestamp - (timestamp % (period * 1000)))
-}
-function calculateCandlewidth(
-  option: ChartRenderOption,
-  chartXSize: number
-): number {
-  return chartXSize / option.renderCandleCount
-}
-function getYAxisScale(data: CandleData[]) {
-  const [min, max] = [
-    d3.min(data, d => d.low_price),
-    d3.max(data, d => d.high_price)
-  ]
-  if (!min || !max) {
-    console.error(data, data.length)
-    console.error('데이터에 문제가 있다. 서버에서 잘못 쏨')
-    return undefined
-  }
-  return d3.scaleLinear().domain([min, max]).range([CHART_AREA_Y_SIZE, 0])
-}
-function getXAxisScale(option: ChartRenderOption, data: CandleData[]) {
-  return d3
-    .scaleTime()
-    .domain([
-      //데이터는 End가 최신 데이터이기 때문에, 순서를 반대로 해야 시간순서대로 들어온다?
-      makeDate(
-        data[option.renderStartDataIndex + option.renderCandleCount].timestamp,
-        60
-      ),
-      makeDate(data[option.renderStartDataIndex].timestamp, 60)
-    ]) //옵션화 필요함
-    .range([0, CHART_AREA_X_SIZE])
-    .nice()
-}
+import {
+  calculateCandlewidth,
+  getYAxisScale,
+  getXAxisScale
+} from '@/utils/chartManager'
+import {
+  CHART_AREA_X_SIZE,
+  CHART_AREA_Y_SIZE,
+  CHART_CONTAINER_X_SIZE,
+  CHART_CONTAINER_Y_SIZE
+} from '@/constants/ChartConstants'
+
 function updateChart(
   svgRef: React.RefObject<SVGSVGElement>,
   data: CandleData[],

--- a/client/components/CandleChart.tsx
+++ b/client/components/CandleChart.tsx
@@ -51,11 +51,6 @@ function updateChart(
   const candleWidth = calculateCandlewidth(option, CHART_AREA_X_SIZE)
   const chartContainer = d3.select(svgRef.current)
   const chartArea = chartContainer.select('svg#chart-area')
-  console.log(
-    '범위',
-    option.renderStartDataIndex,
-    option.renderStartDataIndex + option.renderCandleCount
-  )
   const yAxisScale = getYAxisScale(
     data.slice(
       option.renderStartDataIndex,
@@ -171,7 +166,6 @@ function initChart(
   chartArea.attr('width', CHART_AREA_X_SIZE)
   chartArea.attr('height', CHART_AREA_Y_SIZE)
   chartArea.attr('view')
-  console.error(option.renderStartDataIndex, option.renderCandleCount)
   const yAxisScale = getYAxisScale(
     data.slice(
       option.renderStartDataIndex,

--- a/client/constants/ChartConstants.ts
+++ b/client/constants/ChartConstants.ts
@@ -1,12 +1,11 @@
-import { ChartOption, ChartRenderOption } from '@/types/ChartTypes'
+import { ChartRenderOption } from '@/types/ChartTypes'
 
 export const DEFAULT_CANDLE_COUNT = 2000
-export const DEFAULT_CANDLE_CHART_OPTION: ChartOption = {
-  candlePeriod: '1m',
-  isMovingAverageVisible: false,
-  isVolumeVislble: false
-}
 export const DEFAULT_CANDLER_CHART_RENDER_OPTION: ChartRenderOption = {
+  marketType: 'BTC',
+  candlePeriod: 'minutes/1',
+  isMovingAverageVisible: false,
+  isVolumeVislble: false,
   fetchStartDataIndex: 0,
   fetchCandleCount: DEFAULT_CANDLE_COUNT,
   renderStartDataIndex: 0,

--- a/client/constants/ChartConstants.ts
+++ b/client/constants/ChartConstants.ts
@@ -1,5 +1,12 @@
 import { ChartPeriod, ChartRenderOption } from '@/types/ChartTypes'
 
+export const CHART_CONTAINER_X_SIZE = 1000
+export const CHART_CONTAINER_Y_SIZE = 800
+export const X_RIGHT_MARGIN = 100
+export const Y_RIGHT_MARGIN = 100
+export const CHART_AREA_X_SIZE = CHART_CONTAINER_X_SIZE - X_RIGHT_MARGIN
+export const CHART_AREA_Y_SIZE = CHART_CONTAINER_Y_SIZE - Y_RIGHT_MARGIN
+
 export const DEFAULT_CANDLE_COUNT = 2000
 export const DEFAULT_CANDLE_RENDER_COUNT = 30
 export const DEFAULT_CANDLE_PERIOD: ChartPeriod = 'minutes/1'

--- a/client/constants/ChartConstants.ts
+++ b/client/constants/ChartConstants.ts
@@ -3,7 +3,6 @@ import { ChartOption, ChartRenderOption } from '@/types/ChartTypes'
 export const DEFAULT_CANDLE_COUNT = 2000
 export const DEFAULT_CANDLE_CHART_OPTION: ChartOption = {
   candlePeriod: '1m',
-  defaultCandleCount: 60,
   isMovingAverageVisible: false,
   isVolumeVislble: false
 }

--- a/client/constants/ChartConstants.ts
+++ b/client/constants/ChartConstants.ts
@@ -1,13 +1,14 @@
-import { ChartRenderOption } from '@/types/ChartTypes'
+import { ChartPeriod, ChartRenderOption } from '@/types/ChartTypes'
 
 export const DEFAULT_CANDLE_COUNT = 2000
+export const DEFAULT_CANDLE_RENDER_COUNT = 30
+export const DEFAULT_CANDLE_PERIOD: ChartPeriod = 'minutes/1'
 export const DEFAULT_CANDLER_CHART_RENDER_OPTION: ChartRenderOption = {
   marketType: 'BTC',
-  candlePeriod: 'minutes/1',
   isMovingAverageVisible: false,
   isVolumeVislble: false,
   fetchStartDataIndex: 0,
   fetchCandleCount: DEFAULT_CANDLE_COUNT,
   renderStartDataIndex: 0,
-  renderCandleCount: 20
+  renderCandleCount: DEFAULT_CANDLE_RENDER_COUNT
 }

--- a/client/hooks/useRealTimeUpbitData.ts
+++ b/client/hooks/useRealTimeUpbitData.ts
@@ -1,36 +1,52 @@
-// 여기서 소켓을 연결하는 로직을 작성
-
 import { CandleData } from '@/types/ChartTypes'
-import { SetStateAction, Dispatch, useEffect, useState, useRef } from 'react'
-
+import { useEffect, useState } from 'react'
+import { DatePeriod, ChartPeriod } from '@/types/ChartTypes'
+import { getCandleDataArray } from '@/utils/upbitManager'
 let socket: WebSocket | undefined
 export const useRealTimeUpbitData = (
+  period: ChartPeriod,
   market: string,
   initData: CandleData[]
 ): CandleData[] => {
   const [realtimeCandleData, setRealtimeCandleData] =
     useState<CandleData[]>(initData)
-  const candleData = useRef<CandleData[]>(realtimeCandleData)
+
   useEffect(() => {
-    candleData.current = realtimeCandleData
-  }, [realtimeCandleData])
-  // 1 time 상태를 만들고 boolean
-  //setinterval로요,, 30초에 한번씩 time t f t f
-  //useeffect가요. time을 의존해요
-  //그안에서 manageTradeException 로직을 실행함.
-  useEffect(() => {
-    connectWS(setRealtimeCandleData, market)
+    connectWS(market)
     return () => {
       closeWS()
     }
   }, [])
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const fetched: CandleData[] = await getCandleDataArray(
+        period,
+        market,
+        200
+      )
+      setRealtimeCandleData(fetched)
+    }
+    fetchData()
+    if (!socket) {
+      console.error('분봉 설정 관련 error')
+      return
+    }
+    socket.onmessage = function (e) {
+      const enc = new TextDecoder('utf-8')
+      const arr = new Uint8Array(e.data)
+      const str_d = enc.decode(arr)
+      const d = JSON.parse(str_d)
+      if (d.type == 'ticker') {
+        setRealtimeCandleData(prevData => updateData(prevData, d, period))
+      }
+    }
+  }, [market, period])
+
   return realtimeCandleData //socket을 state해서 같이 뺀다. 변화감지 (끊길때) -> ui표시..
 }
 
-export function connectWS(
-  setData: Dispatch<SetStateAction<CandleData[]>>,
-  market: string
-) {
+export function connectWS(market: string) {
   if (socket != undefined) {
     socket.close()
   }
@@ -43,19 +59,10 @@ export function connectWS(
     )
   }
   socket.onclose = function () {
-    console.log('끊기는지?')
     socket = undefined
   }
-  socket.onmessage = function (e) {
-    const enc = new TextDecoder('utf-8')
-    const arr = new Uint8Array(e.data)
-    const str_d = enc.decode(arr)
-    const d = JSON.parse(str_d)
-    if (d.type == 'ticker') {
-      setData(prevData => updateData(prevData, d))
-    }
-  }
 }
+
 // 웹소켓 연결 해제
 function closeWS() {
   if (socket != undefined) {
@@ -63,10 +70,10 @@ function closeWS() {
     socket = undefined
   }
 }
+
 // 웹소켓 요청
 function filterRequest(filter: string) {
   if (socket == undefined) {
-    alert('no connect exists')
     return
   }
   socket.send(filter)
@@ -74,16 +81,14 @@ function filterRequest(filter: string) {
 
 function updateData(
   prevData: CandleData[],
-  newTickData: CandleData
+  newTickData: CandleData,
+  candlePeriod: ChartPeriod
 ): CandleData[] {
-  newTickData.candle_date_time_kst = transDate(newTickData.trade_timestamp)
-  // newTickData 무조건 ticker로 들어온 데이터
-  // ticker로 들어온 데이터가 클라이언트의 데이터보다 최신아닌 경우 갱신
-  // 최신데이터도 30초룰로 생성됬다
-  // 첫번째 얘를 갱신이아니라 교체를 해줘야되는거아닌가
-  // ticker로 들어온 데이터가 클라이언트의 데이터보다 최신인 경우 추가
+  newTickData.candle_date_time_kst = transDate(
+    newTickData.trade_timestamp,
+    candlePeriod
+  )
   if (prevData[0].candle_date_time_kst === newTickData.candle_date_time_kst) {
-    //console.log('틱 -> 틱')
     prevData[0].low_price = Math.min(
       prevData[0].low_price,
       newTickData.trade_price
@@ -106,8 +111,8 @@ function updateData(
   return [toInsert, ...prevData] //한화면에 보여주는 캔들 * 2
 }
 
-function transDate(timestamp: number, period = 60): string {
-  const date = new Date(timestamp - (timestamp % (period * 1000)))
+function transDate(timestamp: number, period: ChartPeriod): string {
+  const date = new Date(timestamp - (timestamp % (DatePeriod[period] * 1000)))
   date.setHours(date.getHours() + 9)
   return date.toISOString().substring(0, 19)
 }

--- a/client/pages/chart/candlechart/index.tsx
+++ b/client/pages/chart/candlechart/index.tsx
@@ -1,19 +1,44 @@
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next'
-import { CandleData } from '@/types/ChartTypes'
+import { CandleData, ChartPeriod, ChartRenderOption } from '@/types/ChartTypes'
 import { CandleChart } from 'components/CandleChart'
-import { DEFAULT_CANDLE_CHART_OPTION } from '../../../constants/ChartConstants'
+import {
+  DEFAULT_CANDLER_CHART_RENDER_OPTION,
+  DEFAULT_CANDLE_PERIOD
+} from '@/constants/ChartConstants'
 import { getCandleDataArray } from '@/utils/upbitManager'
 import { useRealTimeUpbitData } from 'hooks/useRealTimeUpbitData'
+import { useState } from 'react'
 export default function CandleChartPage({
   candleData
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  const realtimeCandleData = useRealTimeUpbitData('BTC', candleData) //얘가 가공해서 준다.
+  const [candlePeriod, setCandlePeriod] = useState<ChartPeriod>(
+    DEFAULT_CANDLE_PERIOD
+  )
+  const [chartRenderOption, setRenderOption] = useState<ChartRenderOption>(
+    DEFAULT_CANDLER_CHART_RENDER_OPTION
+  )
+  const realtimeCandleData = useRealTimeUpbitData(
+    candlePeriod,
+    chartRenderOption.marketType, //파싱
+    candleData
+  ) //얘가 가공해서 준다.
   return (
     <div>
       <CandleChart
         candleData={realtimeCandleData}
-        option={DEFAULT_CANDLE_CHART_OPTION}
+        option={chartRenderOption}
+        optionSetter={setRenderOption}
       ></CandleChart>
+      <div
+        onClick={() => {
+          setCandlePeriod(prev => {
+            return prev == 'minutes/1' ? 'minutes/60' : 'minutes/1'
+          })
+        }}
+        style={{ fontSize: '2rem' }}
+      >
+        {candlePeriod}분봉
+      </div>
     </div>
   )
 }
@@ -24,7 +49,11 @@ interface CandleChartPageProps {
 export const getServerSideProps: GetServerSideProps<
   CandleChartPageProps
 > = async context => {
-  const fetched: CandleData[] = await getCandleDataArray()
+  const fetched: CandleData[] = await getCandleDataArray(
+    DEFAULT_CANDLE_PERIOD,
+    DEFAULT_CANDLER_CHART_RENDER_OPTION.marketType,
+    200
+  )
   const toret: CandleChartPageProps = {
     candleData: fetched
   } //이것도 함수로 뽑아내는게 나을듯?

--- a/client/types/ChartTypes.ts
+++ b/client/types/ChartTypes.ts
@@ -20,7 +20,6 @@ export interface CandleData {
 
 export interface ChartOption {
   candlePeriod: '1m' | '3m' | '5m' | '1h' | '4h' | '1d' | '1w' | '1d' | '1w'
-  defaultCandleCount: number
   isVolumeVislble: boolean
   isMovingAverageVisible: boolean
 }

--- a/client/types/ChartTypes.ts
+++ b/client/types/ChartTypes.ts
@@ -18,12 +18,32 @@ export interface CandleData {
   trade_timestamp: number
 }
 
-export interface ChartOption {
-  candlePeriod: '1m' | '3m' | '5m' | '1h' | '4h' | '1d' | '1w' | '1d' | '1w'
+type ChartPeriodItered<T> = {
+  [K in ChartPeriod]: T
+}
+export type ChartPeriod =
+  | 'minutes/1'
+  | 'minutes/3'
+  | 'minutes/5'
+  | 'minutes/60'
+  | 'minutes/240'
+  | 'days'
+  | 'weeks'
+export const DatePeriod: ChartPeriodItered<number> = {
+  'minutes/1': 60,
+  'minutes/3': 180,
+  'minutes/5': 300,
+  'minutes/60': 3600,
+  'minutes/240': 14400,
+  days: 86400,
+  weeks: 604800
+}
+
+export interface ChartRenderOption {
+  marketType: string
+  candlePeriod: ChartPeriod
   isVolumeVislble: boolean
   isMovingAverageVisible: boolean
-}
-export interface ChartRenderOption {
   fetchStartDataIndex: number
   fetchCandleCount: number
   renderStartDataIndex: number

--- a/client/types/ChartTypes.ts
+++ b/client/types/ChartTypes.ts
@@ -41,11 +41,10 @@ export const DatePeriod: ChartPeriodItered<number> = {
 
 export interface ChartRenderOption {
   marketType: string
-  candlePeriod: ChartPeriod
-  isVolumeVislble: boolean
-  isMovingAverageVisible: boolean
   fetchStartDataIndex: number
   fetchCandleCount: number
   renderStartDataIndex: number
   renderCandleCount: number
+  isVolumeVislble: boolean
+  isMovingAverageVisible: boolean
 }

--- a/client/utils/chartManager.ts
+++ b/client/utils/chartManager.ts
@@ -1,0 +1,40 @@
+import {
+  CHART_AREA_Y_SIZE,
+  CHART_AREA_X_SIZE
+} from '@/constants/ChartConstants'
+import { ChartRenderOption, CandleData } from '@/types/ChartTypes'
+import * as d3 from 'd3'
+import { makeDate } from './dateManager'
+
+export function calculateCandlewidth(
+  option: ChartRenderOption,
+  chartXSize: number
+): number {
+  return chartXSize / option.renderCandleCount
+}
+export function getYAxisScale(data: CandleData[]) {
+  const [min, max] = [
+    d3.min(data, d => d.low_price),
+    d3.max(data, d => d.high_price)
+  ]
+  if (!min || !max) {
+    console.error(data, data.length)
+    console.error('데이터에 문제가 있다. 서버에서 잘못 쏨')
+    return undefined
+  }
+  return d3.scaleLinear().domain([min, max]).range([CHART_AREA_Y_SIZE, 0])
+}
+export function getXAxisScale(option: ChartRenderOption, data: CandleData[]) {
+  return d3
+    .scaleTime()
+    .domain([
+      //데이터는 End가 최신 데이터이기 때문에, 순서를 반대로 해야 시간순서대로 들어온다?
+      makeDate(
+        data[option.renderStartDataIndex + option.renderCandleCount].timestamp,
+        60
+      ),
+      makeDate(data[option.renderStartDataIndex].timestamp, 60)
+    ]) //옵션화 필요함
+    .range([0, CHART_AREA_X_SIZE])
+    .nice()
+}

--- a/client/utils/dateManager.ts
+++ b/client/utils/dateManager.ts
@@ -1,0 +1,11 @@
+import { ChartPeriod, DatePeriod } from '@/types/ChartTypes'
+
+export function transDate(timestamp: number, period: ChartPeriod): string {
+  const date = new Date(timestamp - (timestamp % (DatePeriod[period] * 1000)))
+  date.setHours(date.getHours() + 9)
+  return date.toISOString().substring(0, 19)
+}
+
+export function makeDate(timestamp: number, period: number): Date {
+  return new Date(timestamp - (timestamp % (period * 1000)))
+}

--- a/client/utils/upbitManager.ts
+++ b/client/utils/upbitManager.ts
@@ -1,12 +1,12 @@
-import { CandleData } from '@/types/ChartTypes'
+import { CandleData, ChartPeriod } from '@/types/ChartTypes'
 import { DEFAULT_CANDLE_COUNT } from '@/constants/ChartConstants'
 export async function getCandleDataArray(
-  period = 1,
-  market = 'BTC',
+  period: ChartPeriod,
+  market: string,
   count = DEFAULT_CANDLE_COUNT
 ): Promise<CandleData[]> {
   const res = await fetch(
-    `https://api.upbit.com/v1/candles/minutes/${period}?market=KRW-${market}&count=${count}`,
+    `https://api.upbit.com/v1/candles/${period}?market=KRW-${market}&count=${count}`,
     {
       method: 'GET',
       headers: { accept: 'application/json' }


### PR DESCRIPTION
## 개요
 * #7 에서 구현한 차트에 옵션으로 몇분봉을 렌더링할지 선택할 수 있게 작업했습니다.

## 작업사항

- refactoring
    - `ChartOption`과 `ChartRenderOption`을 하나로 합침 
    - `ChartRenderOption`과 `CandlePeriod`를 분리
    - `candlePeriod`를 리터럴 타입화, 제너릭 활용하여 리터럴 타입을 매핑하여 객체 생성 및 사용 (client/types/ChartTypes.ts)
    -  매직넘버로 작성되어 있던 candleperiod(==한 캔들에 몇초동안의 기록을 할지)을 변수화
    - 각종 주석 제거


## 생각해볼점
- socket객체의 `onMessage`함수를 갈아끼우는 지금의 구현방식이 best practice인지?
- `market` 옵션도 변경하며 렌더할때는 socket을 다시 connect하게 되는데, 여기서 벌어지는 error를 어떻게 해결할지 잘 모르는 상태, 
   - `market`이 변경될때는 페이지도 reload되기 때문에 상관없는데, SPA구현일때는 어떻게 해결해야할지?

## 이미지
![Nov-21-2022 20-50-26](https://user-images.githubusercontent.com/60903175/203062283-8b20434d-4f88-4d54-aa20-c7db17109614.gif)
주석은 제거되어 PR됨

