### PR TITLE
Issue#8/candle chart represent data(grid)

### DIFF
--- a/client/components/CandleChart.tsx
+++ b/client/components/CandleChart.tsx
@@ -46,7 +46,6 @@ function getXAxisScale(renderOpt: ChartRenderOption, data: CandleData[]) {
       makeDate(data[renderOpt.renderStartDataIndex].timestamp, 60)
     ]) //옵션화 필요함
     .range([0, CHART_AREA_X_SIZE])
-    .nice()
 }
 function updateChart(
   svgRef: React.RefObject<SVGSVGElement>,
@@ -76,11 +75,11 @@ function updateChart(
   chartContainer
     .select<SVGSVGElement>('g#y-axis')
     .attr('transform', `translate(${CHART_AREA_X_SIZE},0)`)
-    .call(d3.axisRight(yAxisScale))
+    .call(d3.axisRight(yAxisScale).tickSizeInner(-1 * CHART_AREA_X_SIZE))
   chartContainer
     .select<SVGSVGElement>('g#x-axis')
     .attr('transform', `translate(0,${CHART_AREA_Y_SIZE})`)
-    .call(d3.axisBottom(xAxisScale))
+    .call(d3.axisBottom(xAxisScale).tickSizeInner(-1 * CHART_AREA_Y_SIZE))
   chartArea
     .selectAll<SVGSVGElement, CandleData>('g')
     .data(data)
@@ -92,7 +91,7 @@ function updateChart(
           .attr('height', d =>
             Math.abs(yAxisScale(d.trade_price) - yAxisScale(d.opening_price))
           )
-          .attr('x', (d, i) => CHART_AREA_X_SIZE - candleWidth * (i + 1))
+          .attr('x', d => xAxisScale(new Date(d.candle_date_time_kst)))
           .attr('y', d =>
             Math.min(yAxisScale(d.trade_price), yAxisScale(d.opening_price))
           )
@@ -102,13 +101,11 @@ function updateChart(
         $g.append('line')
           .attr(
             'x1',
-            (d, i) =>
-              CHART_AREA_X_SIZE + candleWidth / 2 - candleWidth * (i + 1)
+            d => xAxisScale(new Date(d.candle_date_time_kst)) + candleWidth / 2
           )
           .attr(
             'x2',
-            (d, i) =>
-              CHART_AREA_X_SIZE + candleWidth / 2 - candleWidth * (i + 1)
+            d => xAxisScale(new Date(d.candle_date_time_kst)) + candleWidth / 2
           )
           .attr('y1', d => yAxisScale(d.low_price))
           .attr('y2', d => yAxisScale(d.high_price))
@@ -129,7 +126,7 @@ function updateChart(
                   yAxisScale(d.trade_price) - yAxisScale(d.opening_price)
                 )
           )
-          .attr('x', (d, i) => CHART_AREA_X_SIZE - candleWidth * (i + 1))
+          .attr('x', d => xAxisScale(new Date(d.candle_date_time_kst)))
           .attr('y', d =>
             Math.min(yAxisScale(d.trade_price), yAxisScale(d.opening_price))
           )
@@ -138,13 +135,11 @@ function updateChart(
           .select('line')
           .attr(
             'x1',
-            (d, i) =>
-              CHART_AREA_X_SIZE + candleWidth / 2 - candleWidth * (i + 1)
+            d => xAxisScale(new Date(d.candle_date_time_kst)) + candleWidth / 2
           )
           .attr(
             'x2',
-            (d, i) =>
-              CHART_AREA_X_SIZE + candleWidth / 2 - candleWidth * (i + 1)
+            d => xAxisScale(new Date(d.candle_date_time_kst)) + candleWidth / 2
           )
           .attr('y1', d => yAxisScale(d.low_price))
           .attr('y2', d => yAxisScale(d.high_price))
@@ -191,11 +186,11 @@ function initChart(
   chartContainer
     .select<SVGSVGElement>('g#y-axis')
     .attr('transform', `translate(${CHART_AREA_X_SIZE},0)`)
-    .call(d3.axisRight(yAxisScale))
+    .call(d3.axisRight(yAxisScale).tickSizeInner(-1 * CHART_AREA_X_SIZE))
   chartContainer
     .select<SVGSVGElement>('g#x-axis')
     .attr('transform', `translate(0,${CHART_AREA_Y_SIZE})`)
-    .call(d3.axisBottom(xAxisScale))
+    .call(d3.axisBottom(xAxisScale).tickSizeInner(-1 * CHART_AREA_Y_SIZE))
   let transalateX = 0
   let movedCandle = 0
   const zoom = d3
@@ -252,9 +247,9 @@ export const CandleChart: React.FunctionComponent<CandleChartProps> = props => {
   return (
     <div id="chart">
       <svg id="chart-container" ref={chartSvg}>
-        <svg id="chart-area" />
         <g id="y-axis" />
         <g id="x-axis" />
+        <svg id="chart-area" />
       </svg>
     </div>
   )

--- a/client/constants/ChartConstants.ts
+++ b/client/constants/ChartConstants.ts
@@ -11,5 +11,8 @@ export const DEFAULT_CANDLER_CHART_RENDER_OPTION: ChartRenderOption = {
   fetchStartDataIndex: 0,
   fetchCandleCount: DEFAULT_CANDLE_COUNT,
   renderStartDataIndex: 0,
-  renderCandleCount: 20
+  renderCandleCount: 20,
+  translateX: 0
 }
+
+export const MIN_CANDLE_COUNT = 5

--- a/client/types/ChartTypes.ts
+++ b/client/types/ChartTypes.ts
@@ -29,4 +29,5 @@ export interface ChartRenderOption {
   fetchCandleCount: number
   renderStartDataIndex: number
   renderCandleCount: number
+  translateX: number
 }


### PR DESCRIPTION
## 개요
- 캔들차트에 격자생성

## 작업사항
- d3.axis의 tickSizeInner메서드 활용하여 격자 생성(scale의 값마다 lin길이 지정)
  [D3.axis](https://github.com/d3/d3-axis/blob/v3.0.0/README.md#axis_tickSize)
- 격자 생성이후, 캔들차트의 움직임에 격자가 맞지 않는 문제 수정
  ![Nov-22-2022 01-12-32](https://user-images.githubusercontent.com/70005144/203104033-d2175994-a529-424d-a1c6-44d452ceff4d.gif)
  - 기존의 줌/패닝 구현 로직에서는 data배열의 시작인덱스와 차트에 그려지는 캔들의 갯수를 상태로 관리하여 차트를 업데이트했다.
  - 차트의 끝 부분이 정확히 캔들의 끝과 동일하지 않을 경우 격자와 캔들이 맞지 않는 문제
  - 해결하기 위해 상태로 관리하는 renderOption에 translateX속성을 추가하여 캔들의 시작과 끝부분에 온전하지 못한 캔들이 있는지 확인하고 axis의 scale을 조정하는 방식으로 수정하였다.
  ![Nov-22-2022 01-18-53](https://user-images.githubusercontent.com/70005144/203105436-a2f18807-74e6-495a-ae10-502d3705ec56.gif)


