### PR TITLE
feat : useWindowSize 훅 개발

### DIFF
--- a/client/hooks/useWindowSize.ts
+++ b/client/hooks/useWindowSize.ts
@@ -5,6 +5,11 @@ interface WindowSize {
   height: number
 }
 
+/**
+ * DOM 태그의 ref의 width, height를 상태로 return하는 커스텀 훅
+ * @param ref width와 height를 얻길 원하는 html 태그의 ref
+ * @returns  width와 height의 변화하는 상태값
+ */
 export function useWindowSize(ref: React.RefObject<HTMLElement>) {
   const [windowSize, setWindowSize] = useState<WindowSize>({
     width: 0,
@@ -24,6 +29,6 @@ export function useWindowSize(ref: React.RefObject<HTMLElement>) {
     window.addEventListener('resize', handleResize)
     handleResize()
     return () => window.removeEventListener('resize', handleResize)
-  }, [])
+  }, [ref])
   return windowSize
 }

--- a/client/hooks/useWindowSize.ts
+++ b/client/hooks/useWindowSize.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react'
+
+interface WindowSize {
+  width: number
+  height: number
+}
+
+export function useWindowSize(ref: React.RefObject<HTMLElement>) {
+  const [windowSize, setWindowSize] = useState<WindowSize>({
+    width: 0,
+    height: 0
+  })
+  useEffect(() => {
+    function handleResize() {
+      if (ref.current === null) {
+        console.error('useWindow 훅의 매개변수에 이상있음')
+        return
+      }
+      setWindowSize({
+        width: ref.current.getBoundingClientRect().width,
+        height: ref.current.getBoundingClientRect().height
+      })
+    }
+    window.addEventListener('resize', handleResize)
+    handleResize()
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
+  return windowSize
+}


### PR DESCRIPTION
## 개요
- #42 이슈에 대한 PR임
- 차트가 본인의 ElementSize를 알기 위해, 즉 차트 크기를 반응형에 맞추기 위해 선행되어야 하는 훅을 개발함
- **매개변수로 ref를 넣으면, 해당 ref의 사이즈를 return함.**

## 작업사항
- `useWindowSize` 커스텀 훅 개발


## 생각해볼점
- x

## 이미지
<img width="2385" alt="image" src="https://user-images.githubusercontent.com/60903175/204119751-25d3feff-203d-4b58-8f9c-827821604efb.png">
* 동작방식 : 윈도우 사이즈가 변함에 따라 본인의 elementsize가 다시 계산되고, 그에 따른 본인 사이즈를 return해주는 커스텀 훅 결과를 log하였다.