### PR TITLE
feat: 축소, 확대시 y축 스케일 조정, fetch로직 변경 #31

### DIFF
--- a/client/components/CandleChart.tsx
+++ b/client/components/CandleChart.tsx
@@ -252,6 +252,13 @@ function initChart(
   )
 }
 
+function checkNeedFetch(candleData: CandleData[], option: ChartRenderOption) {
+  return (
+    candleData.length <
+    option.renderStartDataIndex + option.renderCandleCount + 100
+  )
+}
+
 export const CandleChart: React.FunctionComponent<CandleChartProps> = props => {
   const chartSvg = React.useRef<SVGSVGElement>(null)
   const [pointerInfo, setPointerInfo] = React.useState<PointerPosition>(
@@ -271,10 +278,7 @@ export const CandleChart: React.FunctionComponent<CandleChartProps> = props => {
 
   React.useEffect(() => {
     //디바운싱 구문
-    if (
-      props.candleData.length <
-      props.option.renderStartDataIndex + props.option.renderCandleCount + 100
-    ) {
+    if (checkNeedFetch(props.candleData, props.option)) {
       // 남은 candleData가 일정개수 이하로 내려가면 Fetch
       if (!isFetching.current) {
         //fetching중인데 한번더 요청이 일어나면 추가fetch 작동하지않음

--- a/client/utils/chartManager.ts
+++ b/client/utils/chartManager.ts
@@ -38,11 +38,7 @@ export function getOffSetX(renderOpt: ChartRenderOption) {
 export function getXAxisScale(option: ChartRenderOption, data: CandleData[]) {
   const offSetX = getOffSetX(option)
   const candleWidth = calculateCandlewidth(option, CHART_AREA_X_SIZE)
-  const index = Math.min(
-    option.renderStartDataIndex + option.renderCandleCount,
-    option.fetchCandleCount + option.fetchStartDataIndex - 1
-  )
-
+  const index = option.renderStartDataIndex + option.renderCandleCount
   return d3
     .scaleTime()
     .domain([


### PR DESCRIPTION
## 개요
기존에 제기가 되었던 fetch로직이 zoom이벤트 안에서만 동작하는 문제와
휠 이벤트시에  차트가 제대로 렌더링 되지 않았던 로직을 수정했습니다.

## 작업사항
- zoom이벤트 시 fetch로직을 바깥쪽 useEffect로 분리
- updateChart가 실행될때(차트가 이동 혹은 확대/축소할때) transform 제대로 적용되도록 변경

## 생각해볼점
- 차트의 wheel 확대이벤트를 걸어줄때 차트들이 오른쪽으로 transform되는 로직을 수정해야할것 같습니다.
휠이벤트를 주는 마우스의 x좌표를 기준을 잡고 차트가 trasform되지않고 캔들차트 개수만 줄어드는 로직으로 수정필요