### PR TITLE
Issue#49/responsive chart

### DIFF
--- a/client/components/CandleChart.tsx
+++ b/client/components/CandleChart.tsx
@@ -26,12 +26,14 @@ import {
 } from '@/constants/ChartConstants'
 import { makeDate } from '@/utils/dateManager'
 import { getCandleDataArray } from '@/utils/upbitManager'
+import { useWindowSize, WindowSize } from 'hooks/useWindowSize'
 
 function updateChart(
   svgRef: React.RefObject<SVGSVGElement>,
   data: CandleData[],
   option: ChartRenderOption,
-  pointerInfo: PointerPosition
+  pointerInfo: PointerPosition,
+  windowSize: WindowSize
 ) {
   const candleWidth = calculateCandlewidth(option, CHART_AREA_X_SIZE)
   const chartContainer = d3.select(svgRef.current)
@@ -261,6 +263,8 @@ function checkNeedFetch(candleData: CandleData[], option: ChartRenderOption) {
 
 export const CandleChart: React.FunctionComponent<CandleChartProps> = props => {
   const chartSvg = React.useRef<SVGSVGElement>(null)
+  const chartContainerRef = React.useRef<HTMLDivElement>(null)
+  const windowSize = useWindowSize(chartContainerRef)
   const [pointerInfo, setPointerInfo] = React.useState<PointerPosition>(
     DEFAULT_POINTER_POSITION
   )
@@ -307,11 +311,21 @@ export const CandleChart: React.FunctionComponent<CandleChartProps> = props => {
       }
       return
     }
-    updateChart(chartSvg, props.candleData, props.option, pointerInfo)
-  }, [props.candleData, props.option, pointerInfo])
+    updateChart(
+      chartSvg,
+      props.candleData,
+      props.option,
+      pointerInfo,
+      windowSize
+    )
+  }, [props.candleData, props.option, pointerInfo, windowSize])
 
   return (
-    <div id="chart">
+    <div
+      id="chart"
+      ref={chartContainerRef}
+      style={{ width: '100%', height: '100%' }}
+    >
       <svg id="chart-container" ref={chartSvg}>
         <g id="y-axis" />
         <svg id="x-axis-container">

--- a/client/components/CandleChart.tsx
+++ b/client/components/CandleChart.tsx
@@ -350,7 +350,11 @@ export const CandleChart: React.FunctionComponent<CandleChartProps> = props => {
     <div
       id="chart"
       ref={chartContainerRef}
-      style={{ width: '100%', height: '100%' }}
+      style={{
+        display: 'flex',
+        width: '100%',
+        height: '100%'
+      }}
     >
       <svg id="chart-container" ref={chartSvg}>
         <g id="y-axis" />

--- a/client/hooks/useWindowSize.ts
+++ b/client/hooks/useWindowSize.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 
-interface WindowSize {
+export interface WindowSize {
   width: number
   height: number
 }
@@ -10,10 +10,10 @@ interface WindowSize {
  * @param ref width와 height를 얻길 원하는 html 태그의 ref
  * @returns  width와 height의 변화하는 상태값
  */
-export function useWindowSize(ref: React.RefObject<HTMLElement>) {
+export function useWindowSize(ref: React.RefObject<Element>) {
   const [windowSize, setWindowSize] = useState<WindowSize>({
-    width: 0,
-    height: 0
+    width: 1000,
+    height: 900
   })
   useEffect(() => {
     function handleResize() {

--- a/client/pages/detail/[market].tsx
+++ b/client/pages/detail/[market].tsx
@@ -36,28 +36,15 @@ export default function Detail({
   return (
     <HomeContainer>
       <ChartContainer>
-        차트공간
         <ChartPeriodSelectorContainer>
           <Chartbutton />
         </ChartPeriodSelectorContainer>
-        <StyledChart>
-          <CandleChart
-            candleData={realtimeCandleData}
-            candleDataSetter={setRealtimeCandleData}
-            option={chartRenderOption}
-            optionSetter={setRenderOption}
-          ></CandleChart>
-          <div
-            onClick={() => {
-              setCandlePeriod(prev => {
-                return prev == 'minutes/1' ? 'minutes/60' : 'minutes/1'
-              })
-            }}
-            style={{ fontSize: '2rem' }}
-          >
-            {candlePeriod}분봉
-          </div>
-        </StyledChart>
+        <CandleChart
+          candleData={realtimeCandleData}
+          candleDataSetter={setRealtimeCandleData}
+          option={chartRenderOption}
+          optionSetter={setRenderOption}
+        ></CandleChart>
       </ChartContainer>
       <InfoContainer>
         {isMobile ? <MobileInfo /> : renderDesktopInfo()}
@@ -106,10 +93,10 @@ function renderDesktopInfo() {
 }
 
 const HomeContainer = styled(Box)`
+  display: flex;
   width: 100%;
   max-width: 1920px;
   height: 100%;
-  display: flex;
   align-items: center;
   ${props => props.theme.breakpoints.down('tablet')} {
     flex-direction: column;
@@ -119,21 +106,18 @@ const HomeContainer = styled(Box)`
 const ChartContainer = styled('div')`
   display: flex;
   box-sizing: content-box;
+  min-width: 300px;
   width: 100%;
   height: calc(100% - 48px);
-  margin: 24px;
   flex-direction: column;
-  justify-content: space-between;
-  border: 1px solid black;
   border-radius: 32px;
   ${props => props.theme.breakpoints.down('tablet')} {
-    margin: 0;
+    height: 50%;
   }
 `
 
 //오른쪽 정보 표시 사이드바
 const InfoContainer = styled(Box)`
-  margin: 24px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -142,34 +126,25 @@ const InfoContainer = styled(Box)`
   width: 390px;
   height: calc(100% - 48px);
   ${props => props.theme.breakpoints.down('tablet')} {
-    transition: height 0.6s ease-in-out;
     margin: 0;
     width: 100%; //매직넘버 제거 및 반응형 관련 작업 필요(모바일에서는 100%)
-    height: calc(70%);
   }
 `
 
 const ChartPeriodSelectorContainer = styled('div')`
+  display: flex;
   width: 100%;
-  height: 10%;
-  min-height: 55px;
+  height: auto;
   background-color: #ffffff;
   border: 1px solid #cac4d0;
-  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   border-radius: 20px;
-  display: flex;
   justify-content: center;
   align-items: center;
-`
-const StyledChart = styled('div')`
-  width: 100%;
-  height: 100%;
-  background-color: #ffffff;
-  border: 1px solid #cac4d0;
-  border-radius: 20px;
+  margin-bottom: 20px;
 `
 
 const StyledRTV = styled('div')`
+  display: flex;
   width: 100%;
   height: 43%;
   background-color: #ffffff;

--- a/client/utils/chartManager.ts
+++ b/client/utils/chartManager.ts
@@ -1,8 +1,4 @@
 import {
-  CHART_AREA_Y_SIZE,
-  CHART_AREA_X_SIZE
-} from '@/constants/ChartConstants'
-import {
   ChartRenderOption,
   CandleData,
   PointerPosition
@@ -16,7 +12,7 @@ export function calculateCandlewidth(
 ): number {
   return chartXSize / option.renderCandleCount
 }
-export function getYAxisScale(data: CandleData[]) {
+export function getYAxisScale(data: CandleData[], CHART_AREA_Y_SIZE: number) {
   const [min, max] = [
     d3.min(data, d => d.low_price),
     d3.max(data, d => d.high_price)
@@ -28,15 +24,22 @@ export function getYAxisScale(data: CandleData[]) {
   }
   return d3.scaleLinear().domain([min, max]).range([CHART_AREA_Y_SIZE, 0])
 }
-export function getOffSetX(renderOpt: ChartRenderOption) {
+export function getOffSetX(
+  renderOpt: ChartRenderOption,
+  CHART_AREA_X_SIZE: number
+) {
   // CHART_AREA_X_SIZE 외부 변수사용
   // renderOpt에 CHART관련 속성 추가 어떨지???
   const candleWidth = calculateCandlewidth(renderOpt, CHART_AREA_X_SIZE)
   return renderOpt.translateX % candleWidth
 }
 // renderOpt period으로 60 대체
-export function getXAxisScale(option: ChartRenderOption, data: CandleData[]) {
-  const offSetX = getOffSetX(option)
+export function getXAxisScale(
+  option: ChartRenderOption,
+  data: CandleData[],
+  CHART_AREA_X_SIZE: number
+) {
+  const offSetX = getOffSetX(option, CHART_AREA_X_SIZE)
   const candleWidth = calculateCandlewidth(option, CHART_AREA_X_SIZE)
   const index = option.renderStartDataIndex + option.renderCandleCount
   return d3
@@ -52,7 +55,8 @@ export function getXAxisScale(option: ChartRenderOption, data: CandleData[]) {
 export function updateCurrentPrice(
   yAxisScale: d3.ScaleLinear<number, number, never>,
   data: CandleData[],
-  renderOpt: ChartRenderOption
+  renderOpt: ChartRenderOption,
+  CHART_AREA_X_SIZE: number
 ) {
   const $currentPrice = d3.select('svg#current-price')
   const yCoord = yAxisScale(data[0].trade_price)
@@ -81,12 +85,15 @@ export function updatePointerUI(
   pointerInfo: PointerPosition,
   yAxisScale: d3.ScaleLinear<number, number, never>,
   renderOpt: ChartRenderOption,
-  data: CandleData[]
+  data: CandleData[],
+  CHART_AREA_X_SIZE: number,
+  CHART_AREA_Y_SIZE: number
 ) {
   const { priceText, color } = getPriceInfo(
     pointerInfo.positionX,
     renderOpt,
-    data
+    data,
+    CHART_AREA_X_SIZE
   )
   d3.select('text#price-info')
     .attr('fill', color ? color : 'black')
@@ -99,15 +106,19 @@ export function updatePointerUI(
       function (enter) {
         const $g = enter.append('g')
         $g.append('path')
-          .attr('d', (d, i) => getPathDAttr(d, i))
+          .attr('d', (d, i) =>
+            getPathDAttr(d, i, CHART_AREA_X_SIZE, CHART_AREA_Y_SIZE)
+          )
           .attr('stroke', 'black')
         $g.append('text')
           .attr('fill', 'black')
           .attr('font-size', 12)
-          .attr('transform', (d, i) => getTextTransform(d, i))
+          .attr('transform', (d, i) =>
+            getTextTransform(d, i, CHART_AREA_X_SIZE, CHART_AREA_Y_SIZE)
+          )
           .text((d, i) => {
             if (i === 0) {
-              return getTimeText(d, renderOpt, data)
+              return getTimeText(d, renderOpt, data, CHART_AREA_X_SIZE)
             }
             return yAxisScale.invert(d)
           })
@@ -116,13 +127,19 @@ export function updatePointerUI(
         return $g
       },
       function (update) {
-        update.select('path').attr('d', (d, i) => getPathDAttr(d, i))
+        update
+          .select('path')
+          .attr('d', (d, i) =>
+            getPathDAttr(d, i, CHART_AREA_X_SIZE, CHART_AREA_Y_SIZE)
+          )
         update
           .select('text')
-          .attr('transform', (d, i) => getTextTransform(d, i))
+          .attr('transform', (d, i) =>
+            getTextTransform(d, i, CHART_AREA_X_SIZE, CHART_AREA_Y_SIZE)
+          )
           .text((d, i) => {
             if (i === 0) {
-              return getTimeText(d, renderOpt, data)
+              return getTimeText(d, renderOpt, data, CHART_AREA_X_SIZE)
             }
             return Math.round(yAxisScale.invert(d))
           })
@@ -137,7 +154,12 @@ export function updatePointerUI(
 }
 
 // text위치 정보 반환
-function getTextTransform(d: number, i: number) {
+function getTextTransform(
+  d: number,
+  i: number,
+  CHART_AREA_X_SIZE: number,
+  CHART_AREA_Y_SIZE: number
+) {
   return i === 0
     ? `translate(${d},${CHART_AREA_Y_SIZE + 3})`
     : `translate(${CHART_AREA_X_SIZE + 3}, ${d})`
@@ -148,30 +170,41 @@ function getTextTransform(d: number, i: number) {
 function getTimeText(
   positionX: number,
   renderOpt: ChartRenderOption,
-  data: CandleData[]
+  data: CandleData[],
+  CHART_AREA_X_SIZE: number
 ) {
   const timeString =
-    data[getDataIndexFromPosX(positionX, renderOpt)].candle_date_time_kst
+    data[getDataIndexFromPosX(positionX, renderOpt, CHART_AREA_X_SIZE)]
+      .candle_date_time_kst
   return `${timeString.substring(5, 10)} ${timeString.substring(11, 16)}`
 }
 
 // 마우스 포인터 x좌표와 renderOpt를 이용해 몇번째 데이터인지 인덱스 반환
-function getDataIndexFromPosX(positionX: number, renderOpt: ChartRenderOption) {
+function getDataIndexFromPosX(
+  positionX: number,
+  renderOpt: ChartRenderOption,
+  CHART_AREA_X_SIZE: number
+) {
   const offSetX = renderOpt.translateX + (CHART_AREA_X_SIZE - positionX)
   const candleWidth = calculateCandlewidth(renderOpt, CHART_AREA_X_SIZE)
-  return Math.floor(offSetX / candleWidth)
+  return Math.floor(offSetX / candleWidth) < 0
+    ? 0
+    : Math.floor(offSetX / candleWidth)
+  //이거 가끔 음수를 return하는데?
 }
 
 // 마우스 포인터가 가르키는 위치의 분봉데이터를 찾아 렌더링될 가격정보를 반환
 function getPriceInfo(
   positionX: number,
   renderOpt: ChartRenderOption,
-  data: CandleData[]
+  data: CandleData[],
+  CHART_AREA_X_SIZE: number
 ) {
   if (positionX < 0) {
     return { priceText: '' }
   }
-  const index = getDataIndexFromPosX(positionX, renderOpt)
+
+  const index = getDataIndexFromPosX(positionX, renderOpt, CHART_AREA_X_SIZE)
   const candleUnitData = data[index]
   return {
     priceText: [
@@ -186,7 +219,12 @@ function getPriceInfo(
 }
 
 // 격자를 생성할 path요소의 내용 index가 0이라면 세로선 1이라면 가로선
-function getPathDAttr(d: number, i: number) {
+function getPathDAttr(
+  d: number,
+  i: number,
+  CHART_AREA_X_SIZE: number,
+  CHART_AREA_Y_SIZE: number
+) {
   return i === 0
     ? `M${d} 0 L${d} ${CHART_AREA_Y_SIZE}`
     : `M0 ${d} L${CHART_AREA_X_SIZE} ${d}`
@@ -199,7 +237,9 @@ function transPointerInfoToArray(pointerInfo: PointerPosition) {
 // 마우스 이벤트 핸들러 포인터의 위치를 파악하고 pointerPosition을 갱신한다.
 export function handleMouseEvent(
   event: MouseEvent,
-  pointerPositionSetter: React.Dispatch<React.SetStateAction<PointerPosition>>
+  pointerPositionSetter: React.Dispatch<React.SetStateAction<PointerPosition>>,
+  CHART_AREA_X_SIZE: number,
+  CHART_AREA_Y_SIZE: number
 ) {
   if (
     event.offsetX >= 0 &&


### PR DESCRIPTION
## 개요
- 화면 크기가 바뀜에 따라 캔들차트 크기가 다르게 렌더링됨

## 작업사항
-  차트 크기를 변수로 변화하는 크기에 맞게 캔들차트를 렌더함
-  `chartManager` 함수 상수 사용에서 창 크기 전달하는 로직으로 수정
-   css 레이아웃 부분 수정
-  다이나믹 라우팅 부분 적용


## 생각해볼점
- 모바일 뷰에서 CSS 레이아웃 height 처리가 잘 안됨. 아래 사진 참조 
    - 동작과 모양엔 문제가 없으나 이유를 잘 몰루겠다..  
<img width="400" alt="image" src="https://user-images.githubusercontent.com/60903175/204303372-f423cad2-95c7-43b3-8637-1a1492f48a9b.png">

## 이미지
![Nov-28-2022 23-37-44](https://user-images.githubusercontent.com/60903175/204304767-60bb7f54-9ba9-4469-be5e-378c066a03ee.gif)


PR에 해당하는 이슈는 우측의 Development에서 등록해주세요!!
