### PR TITLE
Issue#48/candlechart style

### DIFF
--- a/client/components/CandleChart.tsx
+++ b/client/components/CandleChart.tsx
@@ -22,7 +22,11 @@ import {
   DEFAULT_CANDLER_CHART_RENDER_OPTION,
   DEFAULT_CANDLE_PERIOD,
   DEFAULT_POINTER_POSITION,
-  MIN_CANDLE_COUNT
+  MIN_CANDLE_COUNT,
+  CANDLE_COLOR_RED,
+  CANDLE_COLOR_BLUE,
+  CANDLE_CHART_GRID_COLOR,
+  CHART_FONT_SIZE
 } from '@/constants/ChartConstants'
 import { makeDate } from '@/utils/dateManager'
 import { getCandleDataArray } from '@/utils/upbitManager'
@@ -50,7 +54,12 @@ function updateChart(
     .select<SVGSVGElement>('g#y-axis')
     .attr('transform', `translate(${CHART_AREA_X_SIZE},0)`)
     .call(d3.axisRight(yAxisScale).tickSizeInner(-1 * CHART_AREA_X_SIZE))
-    .call(g => g.selectAll('.tick line').attr('stroke', '#EEEFEE'))
+    .call(g => {
+      g.selectAll('.tick line').attr('stroke', CANDLE_CHART_GRID_COLOR)
+      g.selectAll('.tick text')
+        .attr('stroke', 'black')
+        .attr('font-size', CHART_FONT_SIZE)
+    })
   chartContainer
     .select<SVGSVGElement>('g#x-axis')
     .attr('transform', `translate(0,${CHART_AREA_Y_SIZE})`)
@@ -61,7 +70,12 @@ function updateChart(
         .tickSizeOuter(0)
         .ticks(5)
     )
-    .call(g => g.selectAll('.tick line').attr('stroke', '#EEEFEE'))
+    .call(g => {
+      g.selectAll('.tick line').attr('stroke', CANDLE_CHART_GRID_COLOR)
+      g.selectAll('.tick text')
+        .attr('stroke', 'black')
+        .attr('font-size', CHART_FONT_SIZE)
+    })
   updateCurrentPrice(yAxisScale, data, option)
   updatePointerUI(pointerInfo, yAxisScale, option, data)
   chartArea
@@ -95,7 +109,9 @@ function updateChart(
             Math.min(yAxisScale(d.trade_price), yAxisScale(d.opening_price))
           )
           .attr('fill', d =>
-            d.opening_price <= d.trade_price ? 'red' : 'blue'
+            d.opening_price <= d.trade_price
+              ? CANDLE_COLOR_RED
+              : CANDLE_COLOR_BLUE
           )
 
         return $g
@@ -117,7 +133,11 @@ function updateChart(
           .attr('y', d =>
             Math.min(yAxisScale(d.trade_price), yAxisScale(d.opening_price))
           )
-          .attr('fill', d => (d.opening_price < d.trade_price ? 'red' : 'blue'))
+          .attr('fill', d =>
+            d.opening_price < d.trade_price
+              ? CANDLE_COLOR_RED
+              : CANDLE_COLOR_BLUE
+          )
         update
           .select('line')
           .attr(
@@ -132,9 +152,6 @@ function updateChart(
           )
           .attr('y1', d => yAxisScale(d.low_price))
           .attr('y2', d => yAxisScale(d.high_price))
-        // .attr('stroke', d =>
-        //   d.opening_price < d.trade_price ? 'red' : 'blue'
-        // )
         return update
       },
       exit => {
@@ -188,7 +205,12 @@ function initChart(
     .select<SVGSVGElement>('g#y-axis')
     .attr('transform', `translate(${CHART_AREA_X_SIZE},0)`)
     .call(d3.axisRight(yAxisScale).tickSizeInner(-1 * CHART_AREA_X_SIZE))
-    .call(g => g.selectAll('g.tick line').attr('stroke', '#EEEFEE'))
+    .call(g => {
+      g.selectAll('.tick line').attr('stroke', CANDLE_CHART_GRID_COLOR)
+      g.selectAll('.tick text')
+        .attr('stroke', 'black')
+        .attr('font-size', CHART_FONT_SIZE)
+    })
   chartContainer
     .select<SVGSVGElement>('g#x-axis')
     .attr('transform', `translate(0,${CHART_AREA_Y_SIZE})`)
@@ -199,7 +221,12 @@ function initChart(
         .tickSizeInner(-1 * CHART_AREA_Y_SIZE)
         .ticks(5)
     )
-    .call(g => g.selectAll('.tick line').attr('stroke', '#EEEFEE'))
+    .call(g => {
+      g.selectAll('.tick line').attr('stroke', CANDLE_CHART_GRID_COLOR)
+      g.selectAll('.tick text')
+        .attr('stroke', 'black')
+        .attr('font-size', CHART_FONT_SIZE)
+    })
   let transalateX = 0
   let movedCandle = 0
   const zoom = d3
@@ -311,7 +338,7 @@ export const CandleChart: React.FunctionComponent<CandleChartProps> = props => {
       return
     }
     updateChart(chartSvg, props.candleData, props.option, pointerInfo)
-  }, [props.candleData, props.option, pointerInfo])
+  }, [props, props.candleData, props.option, pointerInfo])
 
   return (
     <div id="chart">
@@ -326,7 +353,7 @@ export const CandleChart: React.FunctionComponent<CandleChartProps> = props => {
           <text />
         </svg>
         <svg id="mouse-pointer-UI"></svg>
-        <text id="price-info">sdfsdf</text>
+        <text id="price-info"></text>
       </svg>
     </div>
   )

--- a/client/components/CandleChart.tsx
+++ b/client/components/CandleChart.tsx
@@ -50,6 +50,7 @@ function updateChart(
     .select<SVGSVGElement>('g#y-axis')
     .attr('transform', `translate(${CHART_AREA_X_SIZE},0)`)
     .call(d3.axisRight(yAxisScale).tickSizeInner(-1 * CHART_AREA_X_SIZE))
+    .call(g => g.selectAll('.tick line').attr('stroke', '#EEEFEE'))
   chartContainer
     .select<SVGSVGElement>('g#x-axis')
     .attr('transform', `translate(0,${CHART_AREA_Y_SIZE})`)
@@ -60,6 +61,7 @@ function updateChart(
         .tickSizeOuter(0)
         .ticks(5)
     )
+    .call(g => g.selectAll('.tick line').attr('stroke', '#EEEFEE'))
   updateCurrentPrice(yAxisScale, data, option)
   updatePointerUI(pointerInfo, yAxisScale, option, data)
   chartArea
@@ -69,18 +71,6 @@ function updateChart(
       enter => {
         const $g = enter.append('g')
         $g.attr('transform', `translate(${option.translateX})`) //263번 줄에서 수정, 차트 움직임을 zoom이벤트 ->updateChart에서 관리
-        $g.append('rect')
-          .attr('width', candleWidth * 0.6)
-          .attr('height', d =>
-            Math.abs(yAxisScale(d.trade_price) - yAxisScale(d.opening_price))
-          )
-          .attr('x', (d, i) => CHART_AREA_X_SIZE - candleWidth * (i + 0.8))
-          .attr('y', d =>
-            Math.min(yAxisScale(d.trade_price), yAxisScale(d.opening_price))
-          )
-          .attr('fill', d =>
-            d.opening_price <= d.trade_price ? 'red' : 'blue'
-          )
         $g.append('line')
           .attr(
             'x1',
@@ -94,9 +84,20 @@ function updateChart(
           )
           .attr('y1', d => yAxisScale(d.low_price))
           .attr('y2', d => yAxisScale(d.high_price))
-          .attr('stroke', d =>
+          .attr('stroke', 'black')
+        $g.append('rect')
+          .attr('width', candleWidth * 0.6)
+          .attr('height', d =>
+            Math.abs(yAxisScale(d.trade_price) - yAxisScale(d.opening_price))
+          )
+          .attr('x', (d, i) => CHART_AREA_X_SIZE - candleWidth * (i + 0.8))
+          .attr('y', d =>
+            Math.min(yAxisScale(d.trade_price), yAxisScale(d.opening_price))
+          )
+          .attr('fill', d =>
             d.opening_price <= d.trade_price ? 'red' : 'blue'
           )
+
         return $g
       },
       update => {
@@ -131,9 +132,9 @@ function updateChart(
           )
           .attr('y1', d => yAxisScale(d.low_price))
           .attr('y2', d => yAxisScale(d.high_price))
-          .attr('stroke', d =>
-            d.opening_price < d.trade_price ? 'red' : 'blue'
-          )
+        // .attr('stroke', d =>
+        //   d.opening_price < d.trade_price ? 'red' : 'blue'
+        // )
         return update
       },
       exit => {
@@ -187,6 +188,7 @@ function initChart(
     .select<SVGSVGElement>('g#y-axis')
     .attr('transform', `translate(${CHART_AREA_X_SIZE},0)`)
     .call(d3.axisRight(yAxisScale).tickSizeInner(-1 * CHART_AREA_X_SIZE))
+    .call(g => g.selectAll('g.tick line').attr('stroke', '#EEEFEE'))
   chartContainer
     .select<SVGSVGElement>('g#x-axis')
     .attr('transform', `translate(0,${CHART_AREA_Y_SIZE})`)
@@ -197,6 +199,7 @@ function initChart(
         .tickSizeInner(-1 * CHART_AREA_Y_SIZE)
         .ticks(5)
     )
+    .call(g => g.selectAll('.tick line').attr('stroke', '#EEEFEE'))
   let transalateX = 0
   let movedCandle = 0
   const zoom = d3

--- a/client/constants/ChartConstants.ts
+++ b/client/constants/ChartConstants.ts
@@ -31,3 +31,9 @@ export const DEFAULT_POINTER_POSITION: PointerPosition = {
   positionX: -1,
   positionY: -1
 }
+
+export const CANDLE_COLOR_RED = '#D24F45'
+export const CANDLE_COLOR_BLUE = '#1D61C4'
+export const CANDLE_CHART_GRID_COLOR = '#EEEFEE'
+export const CANDLE_CHART_POINTER_LINE_COLOR = '#999999'
+export const CHART_FONT_SIZE = 15

--- a/client/utils/chartManager.ts
+++ b/client/utils/chartManager.ts
@@ -100,16 +100,16 @@ export function updatePointerUI(
         const $g = enter.append('g')
         $g.append('path')
           .attr('d', (d, i) => getPathDAttr(d, i))
-          .attr('stroke', 'black')
+          .attr('stroke', '#999999')
         $g.append('text')
           .attr('fill', 'black')
-          .attr('font-size', 12)
+          .attr('font-size', 15)
           .attr('transform', (d, i) => getTextTransform(d, i))
           .text((d, i) => {
             if (i === 0) {
               return getTimeText(d, renderOpt, data)
             }
-            return yAxisScale.invert(d)
+            return Math.round(yAxisScale.invert(d)).toLocaleString()
           })
           .attr('text-anchor', (d, i) => (i === 0 ? 'middle' : 'start'))
           .attr('dominant-baseline', (d, i) => (i === 0 ? 'hanging' : 'middle'))
@@ -124,10 +124,8 @@ export function updatePointerUI(
             if (i === 0) {
               return getTimeText(d, renderOpt, data)
             }
-            return Math.round(yAxisScale.invert(d))
+            return Math.round(yAxisScale.invert(d)).toLocaleString()
           })
-          .attr('text-anchor', (d, i) => (i === 0 ? 'middle' : 'start'))
-          .attr('dominant-baseline', (d, i) => (i === 0 ? 'hanging' : 'middle'))
         return update
       },
       function (exit) {

--- a/client/utils/chartManager.ts
+++ b/client/utils/chartManager.ts
@@ -1,6 +1,10 @@
 import {
   CHART_AREA_Y_SIZE,
-  CHART_AREA_X_SIZE
+  CHART_AREA_X_SIZE,
+  CANDLE_COLOR_RED,
+  CANDLE_COLOR_BLUE,
+  CANDLE_CHART_POINTER_LINE_COLOR,
+  CHART_FONT_SIZE
 } from '@/constants/ChartConstants'
 import {
   ChartRenderOption,
@@ -57,7 +61,9 @@ export function updateCurrentPrice(
   const $currentPrice = d3.select('svg#current-price')
   const yCoord = yAxisScale(data[0].trade_price)
   const strokeColor =
-    data[0].opening_price < data[0].trade_price ? 'red' : 'blue'
+    data[0].opening_price < data[0].trade_price
+      ? CANDLE_COLOR_RED
+      : CANDLE_COLOR_BLUE
   $currentPrice
     .select('line')
     .attr('x1', CHART_AREA_X_SIZE)
@@ -70,7 +76,7 @@ export function updateCurrentPrice(
   $currentPrice
     .select('text')
     .attr('fill', strokeColor)
-    .attr('font-size', 15)
+    .attr('font-size', CHART_FONT_SIZE)
     .attr('transform', `translate(${CHART_AREA_X_SIZE + 3}, ${yCoord})`)
     .attr('dominant-baseline', 'middle')
     .text(data[0].trade_price.toLocaleString())
@@ -90,7 +96,7 @@ export function updatePointerUI(
   )
   d3.select('text#price-info')
     .attr('fill', color ? color : 'black')
-    .attr('font-size', 15)
+    .attr('font-size', CHART_FONT_SIZE)
     .text(priceText)
   d3.select('svg#mouse-pointer-UI')
     .selectAll('g')
@@ -100,10 +106,10 @@ export function updatePointerUI(
         const $g = enter.append('g')
         $g.append('path')
           .attr('d', (d, i) => getPathDAttr(d, i))
-          .attr('stroke', '#999999')
+          .attr('stroke', CANDLE_CHART_POINTER_LINE_COLOR)
         $g.append('text')
           .attr('fill', 'black')
-          .attr('font-size', 15)
+          .attr('font-size', CHART_FONT_SIZE)
           .attr('transform', (d, i) => getTextTransform(d, i))
           .text((d, i) => {
             if (i === 0) {
@@ -179,7 +185,9 @@ function getPriceInfo(
       `종가: ${candleUnitData.trade_price}`
     ].join('  '),
     color:
-      candleUnitData.opening_price < candleUnitData.trade_price ? 'red' : 'blue'
+      candleUnitData.opening_price < candleUnitData.trade_price
+        ? CANDLE_COLOR_RED
+        : CANDLE_COLOR_BLUE
   }
 }
 


### PR DESCRIPTION
## 개요
- 캔들차트 스타일링

## 작업사항
- 캔들차트 요소들 색상 지정
- 색상상수화

## 생각해볼점
- MUI의 theme에 색상을 추가하여 재사용할 수 없을까 생각해보았는데, 타입을 지정해 theme을 만들어도 MUI의 theme은 컴포넌트에 전달되어 컴포넌트내부에서 props.theme으로 활용할 수 있었다.
- 기존의 캔들차트에서는 차트를 그려주는 함수내에서 해당 색상정보가 필요하기 때문에 styled를 이용한 컴포넌트로 변경하고 차트를 그리는 함수내에서 클래스명을 지정하거나 함수로 색상정보를 같이 전달하는 방식으로 해결할 수 있을 것 같다.


## 이미지
![스크린샷 2022-11-29 오전 11 05 20](https://user-images.githubusercontent.com/70005144/204420635-e4a019dd-d7e1-437c-8f61-5f91eb5cd988.png)
