### PR TITLE
Issue#55/dynamic routing

### DIFF
--- a/client/components/CandleChart.tsx
+++ b/client/components/CandleChart.tsx
@@ -328,6 +328,10 @@ export const CandleChart: React.FunctionComponent<CandleChartProps> = props => {
             .replaceAll(':', '%3A') //업비트 쿼리문 규칙
         ).then(res => {
           //fetch완료된 newData를 기존 data와 병합
+          if (res === null) {
+            console.error('코인 쿼리 실패, 404에러')
+            return
+          }
           isFetching.current = false
           props.candleDataSetter(prev => {
             return [...prev, ...res]

--- a/client/components/CandleChart.tsx
+++ b/client/components/CandleChart.tsx
@@ -15,7 +15,6 @@ import {
   updatePointerUI
 } from '@/utils/chartManager'
 import {
-  DEFAULT_CANDLER_CHART_RENDER_OPTION,
   DEFAULT_CANDLE_PERIOD,
   DEFAULT_POINTER_POSITION,
   MIN_CANDLE_COUNT
@@ -316,7 +315,7 @@ export const CandleChart: React.FunctionComponent<CandleChartProps> = props => {
         //추가적인 candleData Fetch
         getCandleDataArray(
           DEFAULT_CANDLE_PERIOD,
-          DEFAULT_CANDLER_CHART_RENDER_OPTION.marketType,
+          props.option.marketType,
           200,
           makeDate(
             //endTime설정

--- a/client/hooks/useInterval.ts
+++ b/client/hooks/useInterval.ts
@@ -1,19 +1,22 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react'
 
-export default function useInterval(callback : Function, delay : number | undefined) {
-  const savedCallback = useRef(callback); // 최근에 들어온 callback을 저장할 ref를 하나 만든다.
+export default function useInterval(
+  callback: Function,
+  delay: number | undefined
+) {
+  const savedCallback = useRef(callback) // 최근에 들어온 callback을 저장할 ref를 하나 만든다.
 
   useEffect(() => {
-    savedCallback.current = callback; // callback이 바뀔 때마다 ref를 업데이트 해준다.
-  }, [callback]);
+    savedCallback.current = callback // callback이 바뀔 때마다 ref를 업데이트 해준다.
+  }, [callback])
 
   useEffect(() => {
     const executeCallback = () => {
-      savedCallback.current();
-    };
+      savedCallback.current()
+    }
 
-    const timerId = setInterval(executeCallback, delay);
+    const timerId = setInterval(executeCallback, delay)
 
-    return () => clearInterval(timerId);
-  }, []);
+    return () => clearInterval(timerId)
+  }, [])
 }

--- a/client/hooks/useRealTimeUpbitData.ts
+++ b/client/hooks/useRealTimeUpbitData.ts
@@ -14,7 +14,15 @@ export const useRealTimeUpbitData = (
     useState<CandleData[]>(initData)
   const isInitialMount = useRef(true)
   const fetchData = async () => {
-    const fetched: CandleData[] = await getCandleDataArray(period, market, 200)
+    const fetched: CandleData[] | null = await getCandleDataArray(
+      period,
+      market,
+      200
+    )
+    if (fetched === null) {
+      console.error('코인 쿼리 실패, 404에러')
+      return
+    }
     setRealtimeCandleData(fetched)
   }
 

--- a/client/pages/chart/candlechart/index.tsx
+++ b/client/pages/chart/candlechart/index.tsx
@@ -50,11 +50,20 @@ interface CandleChartPageProps {
 export const getServerSideProps: GetServerSideProps<
   CandleChartPageProps
 > = async context => {
-  const fetched: CandleData[] = await getCandleDataArray(
+  const fetched: CandleData[] | null = await getCandleDataArray(
     DEFAULT_CANDLE_PERIOD,
     DEFAULT_CANDLER_CHART_RENDER_OPTION.marketType,
     200
   )
+
+  if (fetched === null)
+    return {
+      redirect: {
+        permanent: false,
+        destination: '/'
+      }
+    }
+
   const toret: CandleChartPageProps = {
     candleData: fetched
   } //이것도 함수로 뽑아내는게 나을듯?

--- a/client/pages/detail/[market].tsx
+++ b/client/pages/detail/[market].tsx
@@ -81,11 +81,19 @@ export const getServerSideProps: GetServerSideProps<
     }
   }
 
-  const fetchedCandleData: CandleData[] = await getCandleDataArray(
+  const fetchedCandleData: CandleData[] | null = await getCandleDataArray(
     DEFAULT_CANDLE_PERIOD,
     market,
     200
   )
+  if (fetchedCandleData === null) {
+    return {
+      redirect: {
+        permanent: false,
+        destination: '/'
+      }
+    }
+  }
   return {
     props: {
       market: market,

--- a/client/pages/detail/index.tsx
+++ b/client/pages/detail/index.tsx
@@ -1,0 +1,15 @@
+import { GetServerSideProps } from 'next'
+
+//[market] 서브 도메인 없이 접속했을떄 main화면으로 라우팅
+export default function RedirectToMain() {
+  return <div />
+}
+
+export const getServerSideProps: GetServerSideProps = async context => {
+  return {
+    redirect: {
+      permanent: false,
+      destination: '/'
+    }
+  }
+}

--- a/client/types/ChartTypes.ts
+++ b/client/types/ChartTypes.ts
@@ -53,31 +53,31 @@ export interface ChartRenderOption {
 
 //treeChart
 export interface TreeMapData {
-  acc_trade_price: number,
-  acc_trade_price_24h: number,
-  acc_trade_volume: number,
-  acc_trade_volume_24h: number,
-  change: string,
-  change_price: number,
-  change_rate: number,
-  high_price: number,
-  highest_52_week_date: string,
-  highest_52_week_price: number,
-  low_price: number,
-  lowest_52_week_date: string,
-  lowest_52_week_price: number,
-  market: string,
-  opening_price: number,
-  prev_closing_price: number,
-  signed_change_price: number,
-  signed_change_rate: number,
-  timestamp: number,
-  trade_date: string,
-  trade_date_kst: string,
-  trade_price: number,
-  trade_time: string,
-  trade_time_kst: string,
-  trade_timestamp: number,
+  acc_trade_price: number
+  acc_trade_price_24h: number
+  acc_trade_volume: number
+  acc_trade_volume_24h: number
+  change: string
+  change_price: number
+  change_rate: number
+  high_price: number
+  highest_52_week_date: string
+  highest_52_week_price: number
+  low_price: number
+  lowest_52_week_date: string
+  lowest_52_week_price: number
+  market: string
+  opening_price: number
+  prev_closing_price: number
+  signed_change_price: number
+  signed_change_rate: number
+  timestamp: number
+  trade_date: string
+  trade_date_kst: string
+  trade_price: number
+  trade_time: string
+  trade_time_kst: string
+  trade_timestamp: number
   trade_volume: number
 }
 

--- a/client/utils/chartManager.ts
+++ b/client/utils/chartManager.ts
@@ -205,6 +205,10 @@ function getPriceInfo(
   }
 
   const index = getDataIndexFromPosX(positionX, renderOpt, CHART_AREA_X_SIZE)
+  if (index < 0) {
+    console.error('예외상황')
+    return { priceText: '' }
+  }
   const candleUnitData = data[index]
   return {
     priceText: [

--- a/client/utils/upbitManager.ts
+++ b/client/utils/upbitManager.ts
@@ -6,7 +6,7 @@ export async function getCandleDataArray(
   market: string,
   count = DEFAULT_CANDLE_COUNT,
   endTime: string | void
-): Promise<CandleData[]> {
+): Promise<CandleData[] | null> {
   let res
   if (!endTime) {
     res = await fetch(
@@ -25,19 +25,22 @@ export async function getCandleDataArray(
       }
     )
   }
+  if (res.status === 404) {
+    return null
+  }
   const data: CandleData[] = await res.json()
   return data
 }
 
 export async function getTreeMapDataArray(
-  market: string,
+  market: string
 ): Promise<TreeMapData[]> {
   const res = await fetch(
     //market -> markets
     `https://api.upbit.com/v1/ticker?markets=${market}&count=1`,
     {
       method: 'GET',
-      headers: { accept: 'application/json' },
+      headers: { accept: 'application/json' }
     }
   )
   const data: TreeMapData[] = await res.json()
@@ -49,4 +52,3 @@ export async function getCoinTicker() {
   const data = await res.json()
   return data
 }
-


### PR DESCRIPTION
## 개요
-  url로 원하는 코인의 디테일 페이지에 접근 가능하게 처리하였다.

## 작업사항
- `/detail/{market}` 이름으로 해당 코인 캔들차트에 접근 가능
- 없는 코인에 접근시도, 혹은 {market} 없이 /detail 에 접근 시도시, 메인 페이지로 redirect 처리
- lint 규칙 안맞는 파일 일괄 처리

## 생각해볼점
- 예외처리를 한곳에 모아서 하는게 나을지? (express에서 미들웨어 쓰는 것처럼..)
- 메인으로 돌려보내기 전에 alert으로 알려줄지?

## 이미지

![다이나믹 라우팅](https://user-images.githubusercontent.com/60903175/204459301-f9e45c72-e814-40a3-905d-97daa9e3f49e.gif)
- 경로에 따라 알맞은 코인이 렌더링됨

![다이나믹 라우팅 없는 코인](https://user-images.githubusercontent.com/60903175/204459678-a5729872-9f36-4a6a-b55a-2f01fab02216.gif)
- 업비트에 존재하지 않는 코인은 메인으로 돌려보냄

![다이나믹 라우팅 마켓 없을때](https://user-images.githubusercontent.com/60903175/204459693-36350f8e-e045-4d4b-8362-ef6cd3c2cc8a.gif)
- market을 명시하지 않았을때도 메인으로 돌려보냄


