### PR TITLE
Issue#43/use coin metadata hook

### DIFF
--- a/api_server/app.js
+++ b/api_server/app.js
@@ -1,4 +1,6 @@
 const express = require("express");
+const cors = require("cors");
+require("dotenv").config();
 const { getData } = require("./data/configData");
 
 const PORT = 8080;
@@ -18,6 +20,12 @@ setInterval(() => {
 }, 60 * 60 * 1000);
 
 const app = express();
+app.use(
+  cors({
+    origin: process.env.CLIENT_URL,
+    method: "GET",
+  })
+);
 
 app.get("/coin-info/:code", (req, res) => {
   const code = req.params.code;

--- a/api_server/data/configData.js
+++ b/api_server/data/configData.js
@@ -77,15 +77,14 @@ function transPrice(price) {
 async function getData() {
   return getCoinInfo().then((result) => {
     coinInfos = result;
-    marketCapInfos = Object.values(result)
-      .map((coinInfo) => {
-        return {
-          name: coinInfo.symbol,
-          market_cap: coinInfo.market_cap,
-          name_kr: coinInfo.name_kr,
-        };
-      })
-      .sort((a, b) => -a.market_cap + b.market_cap);
+    marketCapInfos = Object.values(result).map((coinInfo) => {
+      return {
+        name: coinInfo.symbol,
+        cmc_rank: coinInfo.cmc_rank,
+        name_kr: coinInfo.name_kr,
+        logo: coinInfo.logo,
+      };
+    });
     return { coinInfos, marketCapInfos };
   });
 }

--- a/api_server/data/configData.js
+++ b/api_server/data/configData.js
@@ -26,6 +26,7 @@ async function getCoinInfo() {
         coinInfo.total_supply = data.total_supply;
         coinInfo.cmc_rank = data.cmc_rank;
         coinInfo.time = time;
+        coinInfo.volume_24h = transPrice(data.quote.KRW.volume_24h);
         coinIds.push(data.id);
         break;
       }
@@ -51,9 +52,7 @@ function getTime() {
   const utcCurr = curr.getTime() + curr.getTimezoneOffset() * 60 * 1000;
   const diffFromKst = 9 * 60 * 60 * 1000;
   const kstCurr = new Date(utcCurr + diffFromKst);
-  const dateString = `${
-    kstCurr.getHours() < 10 ? "0" + kstCurr.getHours() : kstCurr.getHours()
-  }:00`;
+  const dateString = `${kstCurr.getMonth() + 1}/${kstCurr.getDate()} ${kstCurr.getHours()}시`;
   return dateString;
 }
 
@@ -92,22 +91,3 @@ async function getData() {
 }
 
 module.exports = { getCoinInfo, getData };
-
-// 업비트 api의 coin 심볼을 키로하며 객체형식의 코인정보를 값으로 갖는 객체 반환
-// BTC: {
-// 	symbol  코인이름1
-// 	name  코인이름2
-// 	slug  코인이름3
-// 	market_cap_dominance 시장 점유율?
-// 	market_cap 시가총액 number
-// 	market_cap_kr 시가총액 한글로 변환 string
-// 	cmc_rank 시가총액 순위
-// 	max_supply 최대공급량 -> 발행가능한 최대 코인수인듯? null값이 존재하는 유일한 속성
-// 	circulating_supply -> 현재 거래되는 공급량
-// 	total_supply 총 공급량 -> 현재까지 채굴된 코인수인듯?
-// 	website 코인 사이트 링크
-// 	logo 코인 이미지 링크
-// 	description 코인 설명 (영어로 되어있음)
-// 	last_updated 마지막 업데이트 시간 YYYY MM DD HH 00
-//  time 마지막 업데이트 된 시간 01:00 02:00
-// }

--- a/api_server/dataSample/test.js
+++ b/api_server/dataSample/test.js
@@ -72,6 +72,9 @@ function typeCheck(key, coin) {
   if (typeof coin.time !== "string") {
     console.log(key, "time", coin.time);
   }
+  if (typeof coin.volume_24h !== "string") {
+    console.log(key, "volume_24h", coin.volume_24h);
+  }
 }
 
 main();

--- a/api_server/package.json
+++ b/api_server/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "axios": "^0.27.2",
+    "cors": "^2.8.5",
     "debug": "~2.6.9",
     "dotenv": "^16.0.3",
     "express": "~4.16.1",

--- a/api_server/package.json
+++ b/api_server/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "start": "node ./app.js"
+    "start": "node ./app.js",
+    "test": "node ./dataSample/test.js"
   },
   "dependencies": {
     "axios": "^0.27.2",

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -30,6 +30,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
 
 # vercel
 .vercel

--- a/client/components/CoinDetailedInfo/index.tsx
+++ b/client/components/CoinDetailedInfo/index.tsx
@@ -49,27 +49,29 @@ export default function CoinDetailedInfo({ market }: CoinDetailedInfoProps) {
         </BodyHeader>
         <BodyContentContainer>
           <BodyContent key="market_cap_kr">
-            시가총액: {coinMetaData.market_cap_kr}
+            시가총액: {coinMetaData.market_cap_kr}원
+          </BodyContent>
+          <BodyContent key="market_cap_kr">
+            시가총액 순위: {coinMetaData.cmc_rank}위
+          </BodyContent>
+          <BodyContent key="market_cap_kr">
+            24시간 거래량: {coinMetaData.volume_24h}원
           </BodyContent>
           <BodyContent key="max_supply">
             최대 공급량:{' '}
             {coinMetaData.max_supply === null
               ? '미정'
-              : Math.floor(coinMetaData.max_supply).toLocaleString()}
+              : Math.floor(coinMetaData.max_supply).toLocaleString() +
+                coinMetaData.symbol}
           </BodyContent>
           <BodyContent key="total_supply">
-            총 공급량: {Math.floor(coinMetaData.total_supply).toLocaleString()}
+            총 공급량:{' '}
+            {Math.floor(coinMetaData.total_supply).toLocaleString() +
+              coinMetaData.symbol}
           </BodyContent>
           <BodyContent key="description">
             {coinMetaData.description}
           </BodyContent>
-          {/* {Object.keys(mocking).map((key, index: number) => {
-            return (
-              <BodyContent key={key + index}>
-                {key + ':' + mocking[key]}
-              </BodyContent>
-            )
-          })} */}
         </BodyContentContainer>
       </Body>
     </Container>

--- a/client/components/CoinDetailedInfo/index.tsx
+++ b/client/components/CoinDetailedInfo/index.tsx
@@ -2,6 +2,8 @@ import * as React from 'react'
 import { TabProps } from '@/components/InfoContainerMobile/index'
 import { styled } from '@mui/material'
 import Image from 'next/image'
+import { CoinMetaData } from '@/types/CoinDataTypes'
+import { useCoinMetaData } from 'hooks/useCoinMetaData'
 
 type mockingType = {
   [key: string]: string
@@ -24,30 +26,50 @@ interface CoinDetailedInfoProps extends TabProps {
   market: string
 }
 export default function CoinDetailedInfo({ market }: CoinDetailedInfoProps) {
-  return (
+  const coinMetaData: CoinMetaData | null = useCoinMetaData(market)
+  return coinMetaData === null ? (
+    <Container></Container>
+  ) : (
     <Container>
       <Header>
         <HeaderLogo
-          src="https://s2.coinmarketcap.com/static/img/coins/64x64/1.png"
+          src={coinMetaData.logo}
           alt="/logo-only-white.svg"
           width={60}
           height={60}
         />
         <HeaderContent>
-          <div> {'비트코인.. 처럼 한국말이름'}</div>
-          <div> {market}</div>
+          <div> {coinMetaData.name_kr}</div>
+          <div> {coinMetaData.symbol}</div>
         </HeaderContent>
       </Header>
       <Body>
-        <BodyHeader>코인 정보(xx.xx.xx 기준, coinmarketcap 제공)</BodyHeader>
+        <BodyHeader>
+          코인 정보({coinMetaData.time} 기준, coinmarketcap 제공)
+        </BodyHeader>
         <BodyContentContainer>
-          {Object.keys(mocking).map((key, index: number) => {
+          <BodyContent key="market_cap_kr">
+            시가총액: {coinMetaData.market_cap_kr}
+          </BodyContent>
+          <BodyContent key="max_supply">
+            최대 공급량:{' '}
+            {coinMetaData.max_supply === null
+              ? '미정'
+              : Math.floor(coinMetaData.max_supply).toLocaleString()}
+          </BodyContent>
+          <BodyContent key="total_supply">
+            총 공급량: {Math.floor(coinMetaData.total_supply).toLocaleString()}
+          </BodyContent>
+          <BodyContent key="description">
+            {coinMetaData.description}
+          </BodyContent>
+          {/* {Object.keys(mocking).map((key, index: number) => {
             return (
               <BodyContent key={key + index}>
                 {key + ':' + mocking[key]}
               </BodyContent>
             )
-          })}
+          })} */}
         </BodyContentContainer>
       </Body>
     </Container>

--- a/client/hooks/useCoinMetaData.ts
+++ b/client/hooks/useCoinMetaData.ts
@@ -1,0 +1,13 @@
+import { CoinMetaData } from '@/types/CoinDataTypes'
+import { getCoinMetaData } from '@/utils/metaDataManages'
+import { useEffect, useState } from 'react'
+
+export const useCoinMetaData = (coinCode: string): CoinMetaData | null => {
+  const [coinData, setCoinData] = useState<CoinMetaData | null>(null)
+  useEffect(() => {
+    getCoinMetaData(coinCode.toUpperCase()).then(result => {
+      setCoinData(result)
+    })
+  }, [coinCode])
+  return coinData
+}

--- a/client/types/CoinDataTypes.ts
+++ b/client/types/CoinDataTypes.ts
@@ -15,4 +15,5 @@ export interface CoinMetaData {
   website: string
   logo: string
   description: number
+  volume_24h: string
 }

--- a/client/types/CoinDataTypes.ts
+++ b/client/types/CoinDataTypes.ts
@@ -1,0 +1,18 @@
+export interface CoinMetaData {
+  id: number
+  symbol: string
+  name: string
+  name_kr: string
+  slug: string
+  market_cap_dominance: number
+  market_cap: number
+  market_cap_kr: string
+  max_supply: number
+  circulating_supply: number
+  total_supply: number
+  cmc_rank: number
+  time: string
+  website: string
+  logo: string
+  description: number
+}

--- a/client/utils/metaDataManages.ts
+++ b/client/utils/metaDataManages.ts
@@ -1,0 +1,17 @@
+import { CoinMetaData } from '@/types/CoinDataTypes'
+
+export async function getCoinMetaData(
+  coinCode: string
+): Promise<CoinMetaData | null> {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_SERVER_URL}/coin-info/${coinCode}`,
+    {
+      method: 'GET'
+    }
+  )
+  if (response.status !== 200) {
+    return null
+  }
+  const data: CoinMetaData = await response.json()
+  return data
+}


### PR DESCRIPTION
## 개요
- 백엔드서버로 부터 코인의 상세정보를 받아오는 커스텀훅 작성 및 `CoinDetailedInfo`컴포넌트에 정보 반영

## 작업사항
- 코인의 이름을 전달받아 백엔드 서버로부터 코인의 상세정보를 받아오는 커스텀 훅 작성 `hooks/useCoinMetaData.ts`
- 백엔드 서버 cors설정
- `CoinDetailedInfo`컴포넌트에 코인의 정보 렌더링

## 생각해볼점
- 오전 스크럼때 얘기나왔던 시가총액을 기준으로 한 시장 점유율도 추가하려 했지만, 일부 코인들은 시장점유가 0%로 표시되어 시장점유율은 제외하였습니다.
- 설명(description)이 영어로 되어있는데 필요하다면 번역 API사용을 고려해봐도 나쁘지 않을 것 같습니다. (얼마나 잘 번역하는지가 중요)

## 이미지
- 모바일 버전
![스크린샷 2022-12-01 오후 1 12 09](https://user-images.githubusercontent.com/70005144/204964798-3bc2cc8f-1f72-41f5-8bed-f05cdc1d1e7b.png)
- 데스크탑 버전
![스크린샷 2022-12-01 오후 1 12 23](https://user-images.githubusercontent.com/70005144/204964810-23912e91-9290-435e-9f31-22acabae252f.png)


PR에 해당하는 이슈는 우측의 Development에서 등록해주세요!!
