### PR TITLE
Issue#68/search bar autocomplete and redirect

### DIFF
--- a/client/components/GNB/index.tsx
+++ b/client/components/GNB/index.tsx
@@ -1,9 +1,9 @@
 import Image from 'next/image'
 import TextField from '@mui/material/TextField'
-import SearchIcon from '@mui/icons-material/Search'
-import HighlightOffIcon from '@mui/icons-material/HighlightOff'
+
 import { styled } from '@mui/material/styles'
 import { Container, useMediaQuery, useTheme } from '@mui/material'
+import SearchInput from './searchInput'
 
 const GNBContainer = styled('div')`
   display: flex;
@@ -31,21 +31,7 @@ export default function GNB() {
         ) : (
           <Image src="/logo-white.svg" alt="" width={200} height={48} />
         )}
-        <TextField
-          sx={{ marginLeft: 'auto' }}
-          InputProps={{
-            sx: {
-              backgroundColor: 'white',
-              height: '48px',
-              width: { mobile: '100%', tablet: 400, desktop: 600 },
-              p: 2,
-              gap: 2
-            },
-            placeholder: '검색어를 입력하세요',
-            startAdornment: <SearchIcon sx={{ opacity: 0.2 }} />,
-            endAdornment: <HighlightOffIcon sx={{ opacity: 0.2 }} />
-          }}
-        />
+        <SearchInput />
       </Container>
     </GNBContainer>
   )

--- a/client/components/GNB/searchInput.tsx
+++ b/client/components/GNB/searchInput.tsx
@@ -4,51 +4,59 @@ import Stack from '@mui/material/Stack'
 import Autocomplete from '@mui/material/Autocomplete'
 import SearchIcon from '@mui/icons-material/Search'
 import HighlightOffIcon from '@mui/icons-material/HighlightOff'
+import { getMarketCapInfo } from '@/utils/metaDataManages'
+import { MarketCapInfo } from '@/types/CoinDataTypes'
 export default function SearchInput() {
   /* -------------주의------------- */
   // CoinNames의 fetch는 api_server를 이용했습니다.
   // express서버를 키고 작동해야 제대로 받아올 수 있습니다.
-  fetchCoinNames().then(CoinNames => {
-    return (
-      <Stack spacing={2} sx={{ width: 300 }}>
-        <Autocomplete
-          freeSolo
-          id="free-solo-2-demo"
-          disableClearable
-          options={CoinNames.map((coin: any) => coin.name)}
-          renderInput={params => (
-            <TextField
-              sx={{ marginLeft: 'auto' }}
-              {...params}
-              InputProps={{
-                ...params.InputProps,
-                type: 'search',
-                sx: {
-                  backgroundColor: 'white',
-                  height: '48px',
-                  width: { mobile: '100%', tablet: 400, desktop: 600 },
-                  p: 2,
-                  gap: 2
-                },
-                placeholder: '검색어를 입력하세요',
-                startAdornment: <SearchIcon sx={{ opacity: 0.2 }} />,
-                endAdornment: <HighlightOffIcon sx={{ opacity: 0.2 }} />
-              }}
-            />
-          )}
-        />
-      </Stack>
-    )
-  }) //next.js v13
-}
-
-//원래 fetch부분을 SSR로 미리 받아올까했었는데
-//Next.js 13버전에서는 더이상 getServerSideProps를 사용하지 않는다고해서
-//그냥 이렇게 SSG로 만들어 봤습니다. 어차피 저희는 코인 이름만 필요하니까요
-//참고자료 https://youtu.be/5BRFGMs1v_o?t=137
-//참고자료2 https://itchallenger.tistory.com/778
-export async function fetchCoinNames() {
-  const res = await fetch('http://localhost:8080/market-cap-info')
-  const data = await res.json()
-  return data
+  const [CoinNames, setCoinNames] = React.useState<MarketCapInfo[]>([])
+  React.useEffect(() => {
+    async function asyncGetCoinName() {
+      const data: MarketCapInfo[] | null = await getMarketCapInfo()
+      if (!data) {
+        console.error('검색바 자동완성기능 데이터 fetch 에러')
+        return
+      }
+      setCoinNames(data)
+    }
+    asyncGetCoinName()
+  }, [])
+  return (
+    <Stack spacing={2} sx={{ width: 300 }}>
+      <Autocomplete
+        freeSolo
+        id="free-solo-2-demo"
+        disableClearable
+        options={
+          CoinNames.length
+            ? [
+                ...CoinNames.map((coin: MarketCapInfo) => coin.name),
+                ...CoinNames.map((coin: MarketCapInfo) => coin.name_kr)
+              ]
+            : [] //CoinName 검증을 위한 삼항연산자 만일 fetch 되지않았으면 껍데기만 보이게 함
+        }
+        renderInput={params => (
+          <TextField
+            sx={{ marginLeft: 'auto' }}
+            {...params}
+            InputProps={{
+              ...params.InputProps,
+              type: 'search',
+              sx: {
+                backgroundColor: 'white',
+                height: '48px',
+                width: { mobile: '100%', tablet: 400, desktop: 600 },
+                p: 2,
+                gap: 2
+              },
+              placeholder: '검색어를 입력하세요',
+              startAdornment: <SearchIcon sx={{ opacity: 0.2 }} />,
+              endAdornment: <HighlightOffIcon sx={{ opacity: 0.2 }} />
+            }}
+          />
+        )}
+      />
+    </Stack>
+  )
 }

--- a/client/components/GNB/searchInput.tsx
+++ b/client/components/GNB/searchInput.tsx
@@ -54,8 +54,7 @@ export default function SearchInput() {
                 gap: 2
               },
               placeholder: '검색어를 입력하세요',
-              startAdornment: <SearchIcon sx={{ opacity: 0.2 }} />,
-              endAdornment: <HighlightOffIcon sx={{ opacity: 0.2 }} />
+              endAdornment: <SearchIcon sx={{ opacity: 0.2 }} />,
             }}
           />
         )}
@@ -66,7 +65,8 @@ export default function SearchInput() {
             //2.로직을 통과하면 해당 값으로 리다이렉트
             if (validateInputName(CoinNames, inputCoinName)) {
               const engCoinName = matchNameKRwithENG(CoinNames, inputCoinName)
-              router.push(`/detail/${engCoinName}`)
+              //생각해볼점   router.push(`/detail/${engCoinName}`) 
+              window.location.href = `/detail/${engCoinName}`
             }
           }
         }}

--- a/client/components/GNB/searchInput.tsx
+++ b/client/components/GNB/searchInput.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react'
+import TextField from '@mui/material/TextField'
+import Stack from '@mui/material/Stack'
+import Autocomplete from '@mui/material/Autocomplete'
+import SearchIcon from '@mui/icons-material/Search'
+import HighlightOffIcon from '@mui/icons-material/HighlightOff'
+export default function SearchInput() {
+  return (
+    <Stack spacing={2} sx={{ width: 300 }}>
+      <Autocomplete
+        freeSolo
+        id="free-solo-2-demo"
+        disableClearable
+        options={coinInfos.map(option => option.title)}
+        renderInput={params => (
+          <TextField
+            sx={{ marginLeft: 'auto' }}
+            {...params}
+            InputProps={{
+              ...params.InputProps,
+              type: 'search',
+              sx: {
+                backgroundColor: 'white',
+                height: '48px',
+                width: { mobile: '100%', tablet: 400, desktop: 600 },
+                p: 2,
+                gap: 2
+              },
+              placeholder: '검색어를 입력하세요',
+              startAdornment: <SearchIcon sx={{ opacity: 0.2 }} />,
+              endAdornment: <HighlightOffIcon sx={{ opacity: 0.2 }} />
+            }}
+          />
+        )}
+      />
+    </Stack>
+  )
+}
+
+const coinInfos = [
+  { title: 'The Shawshank Redemption', year: 1994 },
+  { title: 'The Godfather', year: 1972 }
+]

--- a/client/components/GNB/searchInput.tsx
+++ b/client/components/GNB/searchInput.tsx
@@ -6,11 +6,14 @@ import SearchIcon from '@mui/icons-material/Search'
 import HighlightOffIcon from '@mui/icons-material/HighlightOff'
 import { getMarketCapInfo } from '@/utils/metaDataManages'
 import { MarketCapInfo } from '@/types/CoinDataTypes'
+import { useRouter } from 'next/router'
+import { matchNameKRwithENG, validateInputName } from '@/utils/inputBarManager'
 export default function SearchInput() {
   /* -------------주의------------- */
   // CoinNames의 fetch는 api_server를 이용했습니다.
   // express서버를 키고 작동해야 제대로 받아올 수 있습니다.
   const [CoinNames, setCoinNames] = React.useState<MarketCapInfo[]>([])
+  const router = useRouter()
   React.useEffect(() => {
     async function asyncGetCoinName() {
       const data: MarketCapInfo[] | null = await getMarketCapInfo()
@@ -56,6 +59,17 @@ export default function SearchInput() {
             }}
           />
         )}
+        onKeyPress={(e: React.KeyboardEvent<HTMLInputElement>) => {
+          const inputCoinName = (e.target as HTMLInputElement).value
+          if (e.key === 'Enter') {
+            //1.입력값이 db에 있는지 검증하는 로직
+            //2.로직을 통과하면 해당 값으로 리다이렉트
+            if (validateInputName(CoinNames, inputCoinName)) {
+              const engCoinName = matchNameKRwithENG(CoinNames, inputCoinName)
+              router.push(`/detail/${engCoinName}`)
+            }
+          }
+        }}
       />
     </Stack>
   )

--- a/client/components/GNB/searchInput.tsx
+++ b/client/components/GNB/searchInput.tsx
@@ -5,39 +5,50 @@ import Autocomplete from '@mui/material/Autocomplete'
 import SearchIcon from '@mui/icons-material/Search'
 import HighlightOffIcon from '@mui/icons-material/HighlightOff'
 export default function SearchInput() {
-  return (
-    <Stack spacing={2} sx={{ width: 300 }}>
-      <Autocomplete
-        freeSolo
-        id="free-solo-2-demo"
-        disableClearable
-        options={coinInfos.map(option => option.title)}
-        renderInput={params => (
-          <TextField
-            sx={{ marginLeft: 'auto' }}
-            {...params}
-            InputProps={{
-              ...params.InputProps,
-              type: 'search',
-              sx: {
-                backgroundColor: 'white',
-                height: '48px',
-                width: { mobile: '100%', tablet: 400, desktop: 600 },
-                p: 2,
-                gap: 2
-              },
-              placeholder: '검색어를 입력하세요',
-              startAdornment: <SearchIcon sx={{ opacity: 0.2 }} />,
-              endAdornment: <HighlightOffIcon sx={{ opacity: 0.2 }} />
-            }}
-          />
-        )}
-      />
-    </Stack>
-  )
+  /* -------------주의------------- */
+  // CoinNames의 fetch는 api_server를 이용했습니다.
+  // express서버를 키고 작동해야 제대로 받아올 수 있습니다.
+  fetchCoinNames().then(CoinNames => {
+    return (
+      <Stack spacing={2} sx={{ width: 300 }}>
+        <Autocomplete
+          freeSolo
+          id="free-solo-2-demo"
+          disableClearable
+          options={CoinNames.map((coin: any) => coin.name)}
+          renderInput={params => (
+            <TextField
+              sx={{ marginLeft: 'auto' }}
+              {...params}
+              InputProps={{
+                ...params.InputProps,
+                type: 'search',
+                sx: {
+                  backgroundColor: 'white',
+                  height: '48px',
+                  width: { mobile: '100%', tablet: 400, desktop: 600 },
+                  p: 2,
+                  gap: 2
+                },
+                placeholder: '검색어를 입력하세요',
+                startAdornment: <SearchIcon sx={{ opacity: 0.2 }} />,
+                endAdornment: <HighlightOffIcon sx={{ opacity: 0.2 }} />
+              }}
+            />
+          )}
+        />
+      </Stack>
+    )
+  }) //next.js v13
 }
 
-const coinInfos = [
-  { title: 'The Shawshank Redemption', year: 1994 },
-  { title: 'The Godfather', year: 1972 }
-]
+//원래 fetch부분을 SSR로 미리 받아올까했었는데
+//Next.js 13버전에서는 더이상 getServerSideProps를 사용하지 않는다고해서
+//그냥 이렇게 SSG로 만들어 봤습니다. 어차피 저희는 코인 이름만 필요하니까요
+//참고자료 https://youtu.be/5BRFGMs1v_o?t=137
+//참고자료2 https://itchallenger.tistory.com/778
+export async function fetchCoinNames() {
+  const res = await fetch('http://localhost:8080/market-cap-info')
+  const data = await res.json()
+  return data
+}

--- a/client/pages/chart/runningchart/index.tsx
+++ b/client/pages/chart/runningchart/index.tsx
@@ -31,7 +31,7 @@ export default function RunningChartPage() {
         coinRate={coinRate}
         WIDTH={1000}
         HEIGHT={800}
-        CANDLECOUNT={100}
+        CANDLECOUNT={15}
       ></RunningChart>
     </>
   )

--- a/client/types/CoinDataTypes.ts
+++ b/client/types/CoinDataTypes.ts
@@ -17,3 +17,10 @@ export interface CoinMetaData {
   description: number
   volume_24h: string
 }
+
+export interface MarketCapInfo {
+  name: string
+  cmc_rank: string
+  name_kr: string
+  logo: string
+}

--- a/client/utils/inputBarManager.ts
+++ b/client/utils/inputBarManager.ts
@@ -1,0 +1,23 @@
+import { MarketCapInfo } from '@/types/CoinDataTypes'
+
+export function validateInputName(
+  coinNames: MarketCapInfo[],
+  inputName: string
+): boolean {
+  const autoCompleteNamesArray = [
+    ...coinNames.map(coin => coin.name),
+    ...coinNames.map(coin => coin.name_kr)
+  ]
+  if (autoCompleteNamesArray.includes(inputName)) return true
+  return false
+}
+
+export function matchNameKRwithENG( //영어이니셜과 한글이름 아무거나 들어와도 모두 영어 이니셜로 필터링
+  coinNames: MarketCapInfo[],
+  inputName: string
+): string {
+  const coinNameObject: MarketCapInfo = coinNames.filter(
+    coin => coin.name === inputName || coin.name_kr === inputName
+  )[0]
+  return coinNameObject.name
+}

--- a/client/utils/metaDataManages.ts
+++ b/client/utils/metaDataManages.ts
@@ -1,4 +1,4 @@
-import { CoinMetaData } from '@/types/CoinDataTypes'
+import { CoinMetaData, MarketCapInfo } from '@/types/CoinDataTypes'
 
 export async function getCoinMetaData(
   coinCode: string
@@ -13,5 +13,16 @@ export async function getCoinMetaData(
     return null
   }
   const data: CoinMetaData = await response.json()
+  return data
+}
+
+export async function getMarketCapInfo(): Promise<MarketCapInfo[] | null> {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_SERVER_URL}/market-cap-info`
+  )
+  if (res.status !== 200) {
+    return null
+  }
+  const data: MarketCapInfo[] = await res.json()
   return data
 }


### PR DESCRIPTION
## 개요
- 검색바 자동완성 기능 추가
- 해당 검색값으로 detail페이지 이동

## 작업사항
- mui autocomplete를 이용한 자동완성 기능을 추가했습니다
  - 자동완성에 필요한 data는 market-cap-info api를 통해 fetch해서 코인의 이니셜과 한글이름으로 사용했습니다.
- 검색창에 타이핑 후 엔터를 누르면 해당 검색값이 실제로 존재하는지 validation 검증을 시작합니다.
- 실제로 배열내에 이름이 존재하면, 한글이름으로 검색있든 이니셜로 검색했든, 이니셜로 통일해서 상세 detailPage로 이동합니다.

## 생각해볼점
- 뭔가 애매한데 불편한지 안불편한지 잘 모르겠어요 아무래도 직접 한번씩 검색바 기능을 체험 해보시고 소감 남겨주시면 좋을것 같습니다.

## 이미지
![검색바 기능시연](https://user-images.githubusercontent.com/61281128/205011778-9bae160e-d225-4560-9ba3-7eaa14657d6f.gif)

