### PR TITLE
러닝차트 1%에서 업데이트 안되고 멈추던 오류 수정

### DIFF
--- a/client/components/CoinSelectController/index.tsx
+++ b/client/components/CoinSelectController/index.tsx
@@ -103,7 +103,6 @@ export default function CoinSelectController(props: CoinSelectControllerProps) {
       [event.target.name]: event.target.checked
     })
   }
-  console.log(checked)
   return (
     <>
       <SelectCoinHead

--- a/client/components/CoinSelectController/index.tsx
+++ b/client/components/CoinSelectController/index.tsx
@@ -103,7 +103,7 @@ export default function CoinSelectController(props: CoinSelectControllerProps) {
       [event.target.name]: event.target.checked
     })
   }
-
+  console.log(checked)
   return (
     <>
       <SelectCoinHead

--- a/client/hooks/reducers/dataReducer.tsx
+++ b/client/hooks/reducers/dataReducer.tsx
@@ -36,6 +36,7 @@ export const dataReducer = (data: CoinRateType, action: ActionType) => {
       if (!action.coinRate) {
         return
       }
+
       const tick = Object.keys(action.coinRate).join(',')
       //tick은 코인들의 이름배열 [KRW-BTC,KRW-ETC 등등]
       getTreeMapDataArray(tick).then(data => {

--- a/client/pages/chart/runningchart/index.tsx
+++ b/client/pages/chart/runningchart/index.tsx
@@ -1,25 +1,28 @@
-import { useState, useEffect, useRef, useReducer } from 'react'
-import { dataReducer } from 'hooks/reducers/dataReducer'
-import { ActionType, EmptyObject, CoinRateType } from '@/types/ChartTypes'
+import { useState, useEffect, useReducer } from 'react'
+import { CoinRateType } from '@/types/ChartTypes'
 import { RunningChart } from '@/components/RunningChart'
+import { getCoinTicker } from '@/utils/upbitManager'
 
 export default function RunningChartPage() {
   const [coinRate, setCoinRate] = useState<CoinRateType>({}) //coin의 등락률 값
-  const [data, dispatch] = useReducer<
-    (
-      data: CoinRateType | EmptyObject,
-      action: ActionType
-    ) => CoinRateType | undefined
-  >(dataReducer, {} as never) //coin의 등락률 변화값을 받아서 coinRate에 넣어줌
+
   useEffect(() => {
-    dispatch({ type: 'init', coinRate: {} }) //coinRate초기세팅
+    const initCoinRate: CoinRateType = {}
+    getCoinTicker().then(data => {
+      for (const key of data) {
+        if (key.market.split('-')[0] === 'KRW') {
+          initCoinRate[key.market] = {
+            name: key.market.split('-')[1],
+            ticker: key.market,
+            parent: 'Origin',
+            value: 0
+          }
+        }
+      }
+      setCoinRate(initCoinRate)
+    })
   }, [])
-  useEffect(() => {
-    setCoinRate(data)
-    // console.log('fetchedData :', data) // : {values} 잘나옴
-    // console.log('fetchedData.keys : ', Object.keys(data)) //: {}빈객체 ???????
-    //위 이슈때문에 coinRate의 빈객체 방지로직을 못짜고 러닝차트 컴포넌트에서 적용했습니다(184 번째 줄)
-  }, [data])
+  if (!Object.keys(coinRate).length) return
   return (
     <>
       <RunningChart coinRate={coinRate} candleCount={20}></RunningChart>

--- a/client/pages/chart/runningchart/index.tsx
+++ b/client/pages/chart/runningchart/index.tsx
@@ -1,12 +1,10 @@
 import { useState, useEffect, useRef, useReducer } from 'react'
-import useInterval from 'hooks/useInterval'
 import { dataReducer } from 'hooks/reducers/dataReducer'
 import { ActionType, EmptyObject, CoinRateType } from '@/types/ChartTypes'
 import { RunningChart } from '@/components/RunningChart'
 
-const COIN_INTERVAL_RATE = 1000
 export default function RunningChartPage() {
-  const [coinRate, setCoinRate] = useState<CoinRateType[]>([]) //coin의 등락률 값
+  const [coinRate, setCoinRate] = useState<CoinRateType>({}) //coin의 등락률 값
   const [data, dispatch] = useReducer<
     (
       data: CoinRateType | EmptyObject,
@@ -14,17 +12,14 @@ export default function RunningChartPage() {
     ) => CoinRateType | undefined
   >(dataReducer, {} as never) //coin의 등락률 변화값을 받아서 coinRate에 넣어줌
   useEffect(() => {
-    dispatch({ type: 'init', coinRate: coinRate[0] }) //coinRate초기세팅
+    dispatch({ type: 'init', coinRate: {} }) //coinRate초기세팅
   }, [])
-
-  useInterval(() => {
-    // 2. 주기적으로 코인 등락률을 업데이트
-    dispatch({ type: 'update', coinRate: coinRate[0] }) //coinRate업데이트
-    if (data) {
-      //비동기 검증
-      setCoinRate([data])
-    }
-  }, COIN_INTERVAL_RATE)
+  useEffect(() => {
+    setCoinRate(data)
+    // console.log('fetchedData :', data) // : {values} 잘나옴
+    // console.log('fetchedData.keys : ', Object.keys(data)) //: {}빈객체 ???????
+    //위 이슈때문에 coinRate의 빈객체 방지로직을 못짜고 러닝차트 컴포넌트에서 적용했습니다(184 번째 줄)
+  }, [data])
   return (
     <>
       <RunningChart coinRate={coinRate} candleCount={20}></RunningChart>


### PR DESCRIPTION
## 개요
- 기존에 일정확률로 변동률이 1%로 고정되고 더이상 바꿔지지 않는 오류를 수정했습니다.

## 작업사항
- 기존 러닝차트 컴포넌트의 props로 전달되던 coinRate부분에서 변화가 생길때마다 컴포넌트가 재렌더링 되는 일을 방지하기 위해 해당 로직을 러닝차트 컴포넌트 내에서 작동하도록 변경했습니다.
- 기존에 사용하던 dataReducer를 삭제했습니다.
## 생각해볼점

