### PR TITLE
Issue#84/main chart connect

### DIFF
--- a/client/components/ChartSelectController/index.tsx
+++ b/client/components/ChartSelectController/index.tsx
@@ -1,12 +1,61 @@
 import * as React from 'react'
-
+import { styled } from '@mui/material/styles'
+import { Dispatch, SetStateAction } from 'react'
+import InputLabel from '@mui/material/InputLabel'
+import Box from '@mui/material/Box'
+import MenuItem from '@mui/material/MenuItem'
+import FormControl from '@mui/material/FormControl'
+import Select, { SelectChangeEvent } from '@mui/material/Select'
+import { ChartTypeArr, ChartType } from '@/types/ChartTypes'
 interface ChartSelectControllerProps {
-  value: number
+  selected: ChartType
+  selectedSetter: Dispatch<SetStateAction<ChartType>>
 }
-
+const ChartPeriodSelectorContainer = styled('div')`
+  display: flex;
+  width: 100%;
+  height: 10%;
+  background-color: #ffffff;
+  box-sizing: border-box;
+  border: 1px solid #cac4d0;
+  border-radius: 20px;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 20px;
+`
 //메인페이지 트리맵/러닝차트 선택 컴포넌트
-export default function ChartSelectController(
-  props: ChartSelectControllerProps
-) {
-  return <div />
+export default function ChartSelectController({
+  selected,
+  selectedSetter
+}: ChartSelectControllerProps) {
+  const handleChange = (event: SelectChangeEvent) => {
+    selectedSetter(event.target.value as ChartType)
+    // as 사용을 지양해야하지만, 런타임 중에
+    // ChartPeriod 이외에 다른 value가 들어올
+    // 가능성이 없으므로 사용함.
+  }
+  return (
+    <ChartPeriodSelectorContainer>
+      <Box sx={{ minWidth: 300 }}>
+        <FormControl fullWidth>
+          <InputLabel id="demo-simple-select-label">차트 선택</InputLabel>
+          <Select
+            labelId="demo-simple-select-label"
+            id="demo-simple-select"
+            value={selected}
+            label="Age"
+            onChange={handleChange}
+          >
+            {ChartTypeArr.map(value => {
+              return (
+                <MenuItem key={value} value={value}>
+                  {value}
+                </MenuItem>
+              )
+            })}
+          </Select>
+        </FormControl>
+      </Box>
+    </ChartPeriodSelectorContainer>
+  )
 }

--- a/client/components/CoinSelectController/index.tsx
+++ b/client/components/CoinSelectController/index.tsx
@@ -9,8 +9,14 @@ import { MarketCapInfo } from '@/types/CoinDataTypes'
 interface CoinChecked {
   [key: string]: boolean
 }
-
-export default function CoinSelectController() {
+interface ChartSelectControllerProps {
+  selectedCoinList: string[]
+  selectedCoinListSetter: React.Dispatch<React.SetStateAction<string[]>>
+}
+export default function CoinSelectController({
+  selectedCoinList,
+  selectedCoinListSetter
+}: ChartSelectControllerProps) {
   const [coinList, setCoinList] = useState<MarketCapInfo[] | null>([])
   const [checked, setChecked] = useState<CoinChecked>({
     all: false

--- a/client/components/RunningChart.tsx
+++ b/client/components/RunningChart.tsx
@@ -8,6 +8,7 @@ import {
 import { useWindowSize } from 'hooks/useWindowSize'
 import useInterval from '@/hooks/useInterval'
 import { getTreeMapDataArray } from '@/utils/upbitManager'
+import { updateTreeData } from './Treechart/getCoinData'
 const COIN_INTERVAL_RATE = 3000
 //------------------------------interface------------------------------
 interface RunningChartProps {
@@ -191,8 +192,13 @@ export const RunningChart: React.FunctionComponent<RunningChartProps> = ({
         value: 0
       }
     })
-    setCoinRate(initCoinRate)
-    GetChartData(initCoinRate) //초기에 로딩없이 바로 렌더될 수 있도록 호출
+    async function update() {
+      const a = await updateTreeData(initCoinRate)
+      setCoinRate(a)
+    }
+    update()
+
+    // GetChartData(initCoinRate) //초기에 로딩없이 바로 렌더될 수 있도록 호출
   }, [])
   React.useEffect(() => {
     initChart(chartSvg, width, height)
@@ -204,7 +210,11 @@ export const RunningChart: React.FunctionComponent<RunningChartProps> = ({
 
   useInterval(() => {
     // 주기적으로 코인 등락률을 업데이트
-    GetChartData(coinRate)
+    async function update() {
+      const a = await updateTreeData(coinRate)
+      setCoinRate(a)
+    }
+    update()
   }, COIN_INTERVAL_RATE)
 
   return (

--- a/client/components/RunningChart.tsx
+++ b/client/components/RunningChart.tsx
@@ -7,8 +7,7 @@ import {
 } from '@/types/ChartTypes'
 import { useWindowSize } from 'hooks/useWindowSize'
 import useInterval from '@/hooks/useInterval'
-import { getTreeMapDataArray } from '@/utils/upbitManager'
-import { updateTreeData } from './Treechart/getCoinData'
+import { updateTreeData } from '@/components/Treechart/getCoinData'
 const COIN_INTERVAL_RATE = 3000
 //------------------------------interface------------------------------
 interface RunningChartProps {
@@ -158,30 +157,12 @@ const updateChart = (
 //------------------------------Component------------------------------
 export const RunningChart: React.FunctionComponent<RunningChartProps> = ({
   candleCount,
-  toRenderCoinTickerList = ['CELO', 'ETH', 'MFT', 'WEMIX']
+  toRenderCoinTickerList = ['BTC']
 }) => {
   const chartContainerRef = React.useRef<HTMLDivElement>(null)
   const chartSvg = React.useRef(null)
   const { width, height } = useWindowSize(chartContainerRef)
   const [coinRate, setCoinRate] = React.useState<CoinRateType>({}) //coin의 등락률 값
-  function GetChartData(coinRate: CoinRateType) {
-    const tick = Object.keys(coinRate).join(',') //CoinRate값의 Key를 활용해서 데이터를 받고,업데이트한다 이거지?
-    getTreeMapDataArray(tick) //트리맵에서 사용하는 메서드 그대로 사용
-      .then(data => {
-        //data는 코인별 실시간 정보
-        // 업비트에 선택된 티커에 대한 코인등락률을 받아와서 기존 데이터 업데이트
-        const tosetData = { ...coinRate }
-        for (const coin of data) {
-          if (tosetData[coin.market]) {
-            tosetData[coin.market].value = Number(
-              (coin.signed_change_rate * 100) //실시간 등락rate를 퍼센테이지로 변경
-                .toFixed(2)
-            ) //소수점 두자리로 fix
-          }
-        }
-        setCoinRate(tosetData)
-      })
-  }
   React.useEffect(() => {
     const initCoinRate: CoinRateType = {}
     toRenderCoinTickerList.forEach(market => {
@@ -197,8 +178,6 @@ export const RunningChart: React.FunctionComponent<RunningChartProps> = ({
       setCoinRate(a)
     }
     update()
-
-    // GetChartData(initCoinRate) //초기에 로딩없이 바로 렌더될 수 있도록 호출
   }, [])
   React.useEffect(() => {
     initChart(chartSvg, width, height)

--- a/client/components/Treechart/getCoinData.tsx
+++ b/client/components/Treechart/getCoinData.tsx
@@ -1,20 +1,18 @@
 import { getTreeMapDataArray } from '@/utils/upbitManager'
 import { CoinRateType } from '@/types/ChartTypes'
 
-export function updateTreeData(coinRate: CoinRateType) {
-  const tick = Object.keys(coinRate).join(',')
+export async function updateTreeData(coinRate: CoinRateType) {
+  const tosetData = { ...coinRate }
+  const tick = Object.keys(tosetData).join(',')
   //tick은 코인들의 이름배열 [KRW-BTC,KRW-ETC 등등]
-  getTreeMapDataArray(tick).then(data => {
-    //data는 코인별 실시간 정보
-    // 업비트에 선택된 티커에 대한 코인등락률을 받아와서 기존 데이터 업데이트
-    for (const coin of data) {
-      if (coinRate[coin.market]) {
-        coinRate[coin.market].value = Number(
-          (coin.signed_change_rate * 100) //실시간 등락rate를 퍼센테이지로 변경
-            .toFixed(2)
-        ) //소수점 두자리로 fix
-      }
+  const allUpbitData = await getTreeMapDataArray(tick)
+  for (const coin of allUpbitData) {
+    if (tosetData[coin.market]) {
+      tosetData[coin.market].value = Number(
+        (coin.signed_change_rate * 100) //실시간 등락rate를 퍼센테이지로 변경
+          .toFixed(2)
+      ) //소수점 두자리로 fix
     }
-  })
-  return coinRate
+  }
+  return tosetData
 }

--- a/client/components/Treechart/index.tsx
+++ b/client/components/Treechart/index.tsx
@@ -198,7 +198,6 @@ const getInitData = (data: MarketCapInfo[]) => {
     coinContent.value = Number((coinData.signed_change_rate * 100).toFixed(2))
     initData[coinContent.ticker] = coinContent
   })
-  console.log(initData)
   return initData
 }
 export interface TreeChartProps {
@@ -223,8 +222,8 @@ export default function TreeChart({
 
   useInterval(() => {
     async function update() {
-      const a = await updateTreeData(coinRate)
-      setCoinRate(a)
+      const updatedCoinRate = await updateTreeData(coinRate)
+      setCoinRate(updatedCoinRate)
     }
     update()
   }, coinIntervalRate)

--- a/client/pages/chart/runningchart/index.tsx
+++ b/client/pages/chart/runningchart/index.tsx
@@ -1,31 +1,9 @@
-import { useState, useEffect, useReducer } from 'react'
-import { CoinRateType } from '@/types/ChartTypes'
 import { RunningChart } from '@/components/RunningChart'
-import { getCoinTicker } from '@/utils/upbitManager'
 
 export default function RunningChartPage() {
-  const [coinRate, setCoinRate] = useState<CoinRateType>({}) //coin의 등락률 값
-
-  useEffect(() => {
-    const initCoinRate: CoinRateType = {}
-    getCoinTicker().then(data => {
-      for (const key of data) {
-        if (key.market.split('-')[0] === 'KRW') {
-          initCoinRate[key.market] = {
-            name: key.market.split('-')[1],
-            ticker: key.market,
-            parent: 'Origin',
-            value: 0
-          }
-        }
-      }
-      setCoinRate(initCoinRate)
-    })
-  }, [])
-  if (!Object.keys(coinRate).length) return
   return (
     <>
-      <RunningChart coinRate={coinRate} candleCount={20}></RunningChart>
+      <RunningChart candleCount={20}></RunningChart>
     </>
   )
 }

--- a/client/pages/chart/treechart/index.tsx
+++ b/client/pages/chart/treechart/index.tsx
@@ -1,7 +1,7 @@
 import { styled } from '@mui/material/styles'
 import { Box } from '@mui/material'
-import TreeChart from '@/components/Treechart'
-import { MarketCapInfo, TreeChartPageProps } from '@/types/CoinDataTypes'
+import TreeChart, { TreeChartProps } from '@/components/Treechart'
+import { MarketCapInfo } from '@/types/CoinDataTypes'
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next'
 import { getMarketCapInfo } from '@/utils/metaDataManages'
 
@@ -16,7 +16,7 @@ export default function TreeChartPage({
 }
 
 export const getServerSideProps: GetServerSideProps<
-  TreeChartPageProps
+  TreeChartProps
 > = async () => {
   const fetchedData: MarketCapInfo[] | null = await getMarketCapInfo()
   return {

--- a/client/types/ChartTypes.ts
+++ b/client/types/ChartTypes.ts
@@ -17,7 +17,8 @@ export interface CandleData {
   timestamp: number
   trade_timestamp: number
 }
-
+export const ChartTypeArr = ['TreeChart', 'RunningChart'] as const
+export type ChartType = typeof ChartTypeArr[number]
 type ChartPeriodItered<T> = {
   [K in ChartPeriod]: T
 }

--- a/client/types/CoinDataTypes.ts
+++ b/client/types/CoinDataTypes.ts
@@ -27,7 +27,3 @@ export interface MarketCapInfo {
   acc_trade_price_24h: number
   signed_change_rate: number
 }
-
-export interface TreeChartPageProps {
-  data: MarketCapInfo[]
-}


### PR DESCRIPTION
## 개요
- #84 이슈를 처리함.
- 메인페이지에 트리/러닝 차트를 임포트했다.

## 작업사항
- 트리차트/러닝차트 리팩터링
    - 공통적으로 state를 직접 변경하는 로직을 모두 제거하고 전부 setter로만 변경하게끔 수정함
    - then함수를 제거하고 전부 async/await로 순서 보장
    - useInterval 내 반복되던 로직을 `updateTreeData` 함수로 통일하여 제거
    - 러닝차트의 경우 선택된 코인만 렌더되도록 로직을 수정함. (treechart는 아직 x)
- 메인페이지에 트리차트/러닝차트 임포트
    - 좌측 상단에 `chartSelectController`로 선택 가능 

## 남은 작업 사항

* 메인 페이지 좌측의 코인선택컴포넌트에서 선택한 코인들이 트리/러닝 차트의 `props`로 전달이 되어야한다. 
* 러닝차트는 전달받은 `props`에 있는 코인들만 렌더되도록 진행했지만, treechart는 아직 x
* 코인선택 컴포넌트에서 선택한 코인이 `['btc','eth','doge']`의 형태로 유지되어야 한다. 현재 코인선택 컴포넌트에서는 다른 객체 모양으로 선택 사항을 유지하고 있어서,  `['btc','eth','doge']`의 상태를 추가하거나, 현재 로직을 변경하거나 둘 중 하나의 선택이 필요함 (추가하는게 나을듯)
* 
## 생각해볼점
- 특히 준태님 @sronger이 열심히 뵈주셔야 합니다..

## 이미지

![Dec-04-2022 21-17-47](https://user-images.githubusercontent.com/60903175/205490816-1d3a13c1-52a7-4ae2-bf52-130b26604c98.gif)

