### PR TITLE
Issue#112/custom hook csr

### DIFF
--- a/client/components/GNB/searchInput.tsx
+++ b/client/components/GNB/searchInput.tsx
@@ -67,8 +67,8 @@ export default function SearchInput() {
               const engCoinName = matchNameKRwithENG(CoinNames, inputCoinName)
               //생각해볼점
               //window.history.pushState('', 'asdf', `/detail/${engCoinName}`)
-              router.replace(`/detail/${engCoinName}`)
-              // window.location.href = `/detail/${engCoinName}`
+              //router.replace(`/detail/${engCoinName}`)
+              window.location.href = `/detail/${engCoinName}`
             }
           }
         }}

--- a/client/components/GNB/searchInput.tsx
+++ b/client/components/GNB/searchInput.tsx
@@ -65,8 +65,10 @@ export default function SearchInput() {
             //2.로직을 통과하면 해당 값으로 리다이렉트
             if (validateInputName(CoinNames, inputCoinName)) {
               const engCoinName = matchNameKRwithENG(CoinNames, inputCoinName)
-              //생각해볼점   router.push(`/detail/${engCoinName}`)
-              window.location.href = `/detail/${engCoinName}`
+              //생각해볼점
+              //window.history.pushState('', 'asdf', `/detail/${engCoinName}`)
+              router.replace(`/detail/${engCoinName}`)
+              // window.location.href = `/detail/${engCoinName}`
             }
           }
         }}

--- a/client/hooks/useURL.ts
+++ b/client/hooks/useURL.ts
@@ -1,0 +1,17 @@
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+
+export function useURL(startMarket: string): string {
+  const router = useRouter()
+  const [market, setMarket] = useState<string>(startMarket)
+  useEffect(() => {
+    const market = Array.isArray(router.query.market)
+      ? router.query.market[0].toUpperCase()
+      : router.query.market?.toUpperCase()
+    if (!market) return
+    setMarket(market)
+    console.log(market, '이게 라우터야')
+  }, [router.query.market])
+
+  return market
+}

--- a/client/hooks/useURL.ts
+++ b/client/hooks/useURL.ts
@@ -10,7 +10,6 @@ export function useURL(startMarket: string): string {
       : router.query.market?.toUpperCase()
     if (!market) return
     setMarket(market)
-    console.log(market, '이게 라우터야')
   }, [router.query.market])
 
   return market

--- a/client/pages/detail/[market].tsx
+++ b/client/pages/detail/[market].tsx
@@ -145,7 +145,6 @@ export const getServerSideProps: GetServerSideProps<
       }
     }
   }
-  console.log(market, '으악')
   return {
     props: {
       market: market,

--- a/client/pages/detail/[market].tsx
+++ b/client/pages/detail/[market].tsx
@@ -12,23 +12,31 @@ import { getCandleDataArray } from '@/utils/upbitManager'
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next'
 import { CandleChart } from '@/components/Candlechart'
 import { useRealTimeUpbitData } from 'hooks/useRealTimeUpbitData'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import CoinDetailedInfo from '@/components/CoinDetailedInfo'
 import RealTimeCoinPrice from '@/components/RealTimeCoinPrice'
 import LinkButton from '@/components/LinkButton'
 import { getPriceInfo } from '@/utils/apiManager'
 import { CoinPriceObj } from '@/types/CoinPriceTypes'
+import { useURL } from '@/hooks/useURL'
 export default function Detail({
   market,
   candleData,
   priceInfo
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const theme = useTheme()
+  const marketParsedInURL = useURL(market)
   const isMobile = useMediaQuery(theme.breakpoints.down('tablet'))
+
   const [chartRenderOption, setRenderOption] = useState<ChartRenderOption>({
     ...DEFAULT_CANDLER_CHART_RENDER_OPTION,
     marketType: market
   })
+  useEffect(() => {
+    setRenderOption(prev => {
+      return { ...prev, marketType: marketParsedInURL }
+    })
+  }, [marketParsedInURL])
   const [candlePeriod, setCandlePeriod] = useState<ChartPeriod>(
     DEFAULT_CANDLE_PERIOD
   )
@@ -137,6 +145,7 @@ export const getServerSideProps: GetServerSideProps<
       }
     }
   }
+  console.log(market, '으악')
   return {
     props: {
       market: market,


### PR DESCRIPTION
## 개요
- CSR로 차트를 업데이트 할수 있도록 (서버로 요청없이) 수정
    - `Router.replace`로 쿼리스트링을 변화시키면 요청없이 마켓 페이지가 업데이트된다.

## 작업사항
- `useRealTImeUpbitData` 훅을 리팩터링 했습니다.
    - `useRef`를 활용해서 소켓의 onMessage 함수를 컨트롤합니다.  
- `useURL` 커스텀 훅을 제작했습니다.
    - next.js의 router를 활용해서, 쿼리스트링의 변화를 감지하는 훅입니다. 

## 생각해볼점
- 소켓 리팩터링하면서 머리털 다 빠질 뻔했으나, 안정적으로 동작하는 것 확인하고 PR올립니다.
    - 훅이 좀더 깔끔해졌습니다. 

## 이미지


PR에 해당하는 이슈는 우측의 Development에서 등록해주세요!!
