### PR TITLE
Issue#120/running descending color bugfix

### DIFF
--- a/client/components/GNB/index.tsx
+++ b/client/components/GNB/index.tsx
@@ -29,6 +29,7 @@ const GNBContainer = styled('div')`
 export default function GNB() {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('tablet'))
+  const router = useRouter()
   return (
     <GNBContainer>
       <Container
@@ -41,9 +42,9 @@ export default function GNB() {
         }}
       >
         {isMobile ? (
-          //Router.push / Router.replace / Link태그 사용시 메인페이지->메인페이지 새로고침 불가능
+          //Router.push / Router.replace / Link태그 사용시 메인페이지->메인페이지 새로고침 불가능 => reload로 해결
           //ex)코인선택 기능을 여러번 사용하고 트리맵화면에서 logo아이콘 클릭시 다시 기본세팅 (코인세팅 전부 , 러닝차트 descending) 되지않음
-          <a href="/">
+          <Link href="/" onClick={() => router.reload()}>
             <Image
               style={{ paddingRight: '16px' }}
               src="/logo-only-white.svg"
@@ -51,17 +52,11 @@ export default function GNB() {
               width={40}
               height={40}
             />
-          </a>
+          </Link>
         ) : (
-          <a href="/">
-            <Image
-              // onClick={goToMainRoute} <= 해당방법 사용하면 마우스 갖다댔을때 누를수있음을 표시하는 마우스 아이콘 변화가 일어나지않음
-              src="/logo-white.svg"
-              alt=""
-              width={200}
-              height={48}
-            />
-          </a>
+          <Link href="/" onClick={() => router.reload()}>
+            <Image src="/logo-white.svg" alt="" width={200} height={48} />
+          </Link>
         )}
         <SearchInput />
       </Container>

--- a/client/components/Runningchart/index.tsx
+++ b/client/components/Runningchart/index.tsx
@@ -53,24 +53,17 @@ const updateChart = (
     }
     return d3.ascending(a.cmc_rank, b.cmc_rank) //시가총액
   })
-  const min =
-    selectedSort !== 'descending'
-      ? selectedSort === 'market capitalization'
-        ? (d3.min(ArrayDataValue, d => d.market_cap) as number)
-        : (d3.min(ArrayDataValue, d => Math.abs(d.value)) as number)
-      : (d3.min(ArrayDataValue, d => d.value) as number)
   const max =
     selectedSort !== 'descending'
       ? selectedSort === 'market capitalization'
-        ? (d3.max(ArrayDataValue, d => d.market_cap) as number)
-        : (d3.max(ArrayDataValue, d => Math.abs(d.value)) as number)
-      : (d3.max(ArrayDataValue, d => d.value) as number)
-  const threshold =
-    Math.max(Math.abs(min), max) <= 66
-      ? Math.max(Math.abs(min), max) <= 33
-        ? 33
-        : 66
-      : Math.max(Math.abs(min), max, 100) // 66보다 큰 경우는 시가총액 or 66% 이상
+        ? d3.max(ArrayDataValue, d => d.market_cap)
+        : d3.max(ArrayDataValue, d => Math.abs(d.value))
+      : d3.max(ArrayDataValue, d => Math.abs(d.value))
+  if (!max) {
+    console.error('정상적인 등락률 데이터가 아닙니다.')
+    return
+  }
+  const threshold = max <= 66 ? (max <= 33 ? 33 : 66) : Math.max(max, 100) // 66보다 큰 경우는 시가총액 or 66% 이상
   const domainRange = [0, threshold]
 
   const barMargin = height / 10 / 5 //바 사이사이 마진값
@@ -116,10 +109,10 @@ const updateChart = (
           })
           .attr('height', barHeight)
           .style('fill', (d, i) => {
-            if (d.value > 0) return colorQuantizeScale(min, max, d.value)
+            if (d.value > 0) return colorQuantizeScale(max, d.value)
             else if (d.value === 0) return 'gray'
             else {
-              return colorQuantizeScale(min, max, d.value)
+              return colorQuantizeScale(max, d.value)
             }
           })
 
@@ -188,9 +181,9 @@ const updateChart = (
           })
           .attr('height', barHeight)
           .style('fill', (d, i) => {
-            if (d.value > 0) return colorQuantizeScale(min, max, d.value)
+            if (d.value > 0) return colorQuantizeScale(max, d.value)
             else if (d.value === 0) return 'gray'
-            else return colorQuantizeScale(min, max, d.value)
+            else return colorQuantizeScale(max, d.value)
           })
         update
           .select('text')

--- a/client/components/Runningchart/index.tsx
+++ b/client/components/Runningchart/index.tsx
@@ -43,26 +43,34 @@ const updateChart = (
   const ArrayDataValue: CoinRateContentType[] = [
     ...Object.values<CoinRateContentType>(data)
   ].sort((a, b) => {
-    if (selectedSort === 'descending') {
-      return d3.descending(a.value, b.value) // 내림차순
+    switch (selectedSort) {
+      case 'descending':
+        return d3.descending(a.value, b.value) // 내림차순
+      case 'ascending':
+        return d3.ascending(a.value, b.value) // 오름차순
+      case 'absolute':
+        return d3.descending(Math.abs(a.value), Math.abs(b.value)) // 절댓값
+      case 'trade price':
+        return d3.descending(a.acc_trade_price_24h, b.acc_trade_price_24h) // 거래량
+      default:
+        return d3.descending(a.market_cap, b.market_cap) //시가총액
     }
-    if (selectedSort === 'ascending') {
-      return d3.ascending(a.value, b.value) // 오름차순
-    }
-    if (selectedSort === 'absolute') {
-      return d3.descending(Math.abs(a.value), Math.abs(b.value)) // 절댓값
-    }
-    if (selectedSort === 'trade price') {
-      return d3.descending(a.acc_trade_price_24h, b.acc_trade_price_24h) // 거래량
-    }
-    return d3.ascending(a.market_cap, b.market_cap) //시가총액
   })
-  const max =
-    selectedSort !== 'descending'
-      ? selectedSort === 'market capitalization'
-        ? d3.max(ArrayDataValue, d => d.market_cap)
-        : d3.max(ArrayDataValue, d => Math.abs(d.value))
-      : d3.max(ArrayDataValue, d => Math.abs(d.value))
+  const max = (() => {
+    switch (selectedSort) {
+      case 'descending':
+        return d3.max(ArrayDataValue, d => Math.abs(d.value)) // 내림차순
+      case 'ascending':
+        return d3.max(ArrayDataValue, d => Math.abs(d.value)) // 오름차순
+      case 'absolute':
+        return d3.max(ArrayDataValue, d => Math.abs(d.value)) // 절댓값
+      case 'trade price':
+        return d3.max(ArrayDataValue, d => d.acc_trade_price_24h) // 거래량
+      default:
+        return d3.max(ArrayDataValue, d => d.market_cap) //시가총액
+    }
+  })()
+
   if (!max) {
     console.error('정상적인 등락률 데이터가 아닙니다.')
     return
@@ -103,6 +111,7 @@ const updateChart = (
 
         $g.append('rect')
           .attr('width', function (d) {
+            // console.log(d.acc_trade_price_24h)
             return scale(
               selectedSort !== 'trade price'
                 ? selectedSort !== 'market capitalization'

--- a/client/components/Treechart/index.tsx
+++ b/client/components/Treechart/index.tsx
@@ -88,9 +88,9 @@ const updateChart = (
           .attr('fill', function (d) {
             return d.data.value >= 0
               ? d.data.value > 0
-                ? colorQuantizeScale(min, max, d.data.value)
+                ? colorQuantizeScale(max, d.data.value)
                 : 'black'
-              : colorQuantizeScale(min, max, d.data.value)
+              : colorQuantizeScale(min, d.data.value)
           })
           .style('stroke', 'black')
         $g.append('text')
@@ -135,9 +135,9 @@ const updateChart = (
           .attr('fill', function (d) {
             return d.data.value >= 0
               ? d.data.value > 0
-                ? colorQuantizeScale(min, max, d.data.value)
+                ? colorQuantizeScale(max, d.data.value)
                 : 'black'
-              : colorQuantizeScale(min, max, d.data.value)
+              : colorQuantizeScale(min, d.data.value)
           })
           .transition()
           .duration(500)

--- a/client/components/Treechart/index.tsx
+++ b/client/components/Treechart/index.tsx
@@ -95,10 +95,10 @@ const updateChart = (
             return d.data.value >= 0
               ? d.data.value > 0
                 ? colorQuantizeScale(max, d.data.value)
-                : 'black'
+                : 'gray'
               : colorQuantizeScale(min, d.data.value)
           })
-          .style('stroke', 'black')
+          .style('stroke', 'gray')
         $g.append('text')
           .attr('x', function (d) {
             return d.x0 + Math.abs(d.x1 - d.x0) / 2
@@ -143,12 +143,12 @@ const updateChart = (
             return d.data.value >= 0
               ? d.data.value > 0
                 ? colorQuantizeScale(max, d.data.value)
-                : 'black'
+                : 'gray'
               : colorQuantizeScale(min, d.data.value)
           })
           .transition()
           .duration(500)
-          .style('stroke', 'black')
+          .style('stroke', 'gray')
         update
           .select('text')
           .transition()

--- a/client/utils/chartManager.ts
+++ b/client/utils/chartManager.ts
@@ -353,12 +353,10 @@ export function goToFuture(props: CandleChartProps, windowSize: WindowSize) {
   }
 }
 
-export const colorQuantizeScale = (min: number, max: number, value: number) => {
+export const colorQuantizeScale = (max: number, value: number) => {
   return value > 0
-    ? d3.scaleQuantize<string>().domain([min, max]).range(redColorScale)(
-        Math.abs(value)
-      )
-    : d3.scaleQuantize<string>().domain([min, max]).range(blueColorScale)(
+    ? d3.scaleQuantize<string>().domain([0, max]).range(redColorScale)(value)
+    : d3.scaleQuantize<string>().domain([0, max]).range(blueColorScale)(
         Math.abs(value)
       )
 }


### PR DESCRIPTION
## 개요
- #120 이슈를 해결했습니다.

## 작업사항
- domain범위를 0~max값으로 설정하여 min값 삭제
- 색상 scale 작게 로직 수정
- 트리맵 0% 검은색에서 회색으로 수정
## 생각해볼점
- market capitalization이랑 지금 PR올라가있는 거래량 차트 색상이 등락률 기준으로 되어있는데 이대로 두어도 될까요 아니면 다른 색상을 적용해야할까요?
![image](https://user-images.githubusercontent.com/61281128/206362259-15784c21-f85d-4ef8-8c80-1189899f4042.png)
