### PR TITLE
feat : GNB logo 메인페이지 라우팅 적용 / 로고 좌우 패딩값 일치 / 검색바길이 재조정

### DIFF
--- a/client/components/GNB/index.tsx
+++ b/client/components/GNB/index.tsx
@@ -2,6 +2,7 @@ import Image from 'next/image'
 import { styled } from '@mui/material/styles'
 import { Container, useMediaQuery, useTheme } from '@mui/material'
 import SearchInput from './searchInput'
+import Link from 'next/link'
 
 const GNBContainer = styled('div')`
   position: fixed;
@@ -34,13 +35,24 @@ export default function GNB() {
         id="GNBcontainer"
         sx={{
           display: 'flex',
-          alignItems: 'center'
+          alignItems: 'center',
+          paddingLeft: '16px'
         }}
       >
         {isMobile ? (
-          <Image src="/logo-only-white.svg" alt="" width={40} height={40} />
+          <Link href="/">
+            <Image
+              style={{ paddingRight: '16px' }}
+              src="/logo-only-white.svg"
+              alt=""
+              width={40}
+              height={40}
+            />
+          </Link>
         ) : (
-          <Image src="/logo-white.svg" alt="" width={200} height={48} />
+          <Link href="/">
+            <Image src="/logo-white.svg" alt="" width={200} height={48} />
+          </Link>
         )}
         <SearchInput />
       </Container>

--- a/client/components/GNB/index.tsx
+++ b/client/components/GNB/index.tsx
@@ -3,6 +3,7 @@ import { styled } from '@mui/material/styles'
 import { Container, useMediaQuery, useTheme } from '@mui/material'
 import SearchInput from './searchInput'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 
 const GNBContainer = styled('div')`
   position: fixed;
@@ -40,7 +41,9 @@ export default function GNB() {
         }}
       >
         {isMobile ? (
-          <Link href="/">
+          //Router.push / Router.replace / Link태그 사용시 메인페이지->메인페이지 새로고침 불가능
+          //ex)코인선택 기능을 여러번 사용하고 트리맵화면에서 logo아이콘 클릭시 다시 기본세팅 (코인세팅 전부 , 러닝차트 descending) 되지않음
+          <a href="/">
             <Image
               style={{ paddingRight: '16px' }}
               src="/logo-only-white.svg"
@@ -48,11 +51,17 @@ export default function GNB() {
               width={40}
               height={40}
             />
-          </Link>
+          </a>
         ) : (
-          <Link href="/">
-            <Image src="/logo-white.svg" alt="" width={200} height={48} />
-          </Link>
+          <a href="/">
+            <Image
+              // onClick={goToMainRoute} <= 해당방법 사용하면 마우스 갖다댔을때 누를수있음을 표시하는 마우스 아이콘 변화가 일어나지않음
+              src="/logo-white.svg"
+              alt=""
+              width={200}
+              height={48}
+            />
+          </a>
         )}
         <SearchInput />
       </Container>

--- a/client/components/GNB/searchInput.tsx
+++ b/client/components/GNB/searchInput.tsx
@@ -26,7 +26,7 @@ export default function SearchInput() {
     asyncGetCoinName()
   }, [])
   return (
-    <Stack spacing={2} sx={{ width: 300 }}>
+    <Stack spacing={2} sx={{ width: 400 }}>
       <Autocomplete
         freeSolo
         id="free-solo-2-demo"


### PR DESCRIPTION
## 개요
- GNB logo 메인페이지 라우팅 적용 / 로고 좌우 패딩값 일치 / 검색바길이 재조정 #123 

## 작업사항
- 로고를 Link태그로 라우팅 적용했습니다.
- 기존 모바일에서 로고와 검색바 사이 패딩값이 없던 것을 수정했습니다.
- 검색바 길이 기본 300px을 모바일에서 꽉찬 느낌이들게 400px로 늘렸습니다.

## 생각해볼점
- gif를 보면 아시겠지만  CSR 로 구성되다보니 메인페이지로 리턴할때, 그래프를 불러올때까지 라우팅이 완료되는 시간이 꽤 긴 것을 알 수 있습니다.
- 주소값은 바뀌는데 몇초동안 렌더링이 완료가 안되서 제가 이용자라면 몇초동안 어 왜 안돌아가지지?하고 계속 버튼을 누를것 같아요
- 이동중이라는 SSG 로딩창을 추가해야 할까요?

## 이미지

![GNB라우팅2](https://user-images.githubusercontent.com/61281128/206376048-1ad8e94b-d48f-43ac-b42c-7b3ca1057c6d.gif)

