### PR TITLE
issue#135 트리/러닝 차트 이벤트 버블링 수정

### DIFF
--- a/client/components/Runningchart/index.tsx
+++ b/client/components/Runningchart/index.tsx
@@ -102,7 +102,9 @@ const updateChart = (
     .data(ArrayDataValue, d => d.name)
     .join(
       enter => {
-        const $g = enter.append('g')
+        const $g = enter.append('g').on('click', function (e, d) {
+          nodeOnclickHandler(d.ticker.split('-')[1])
+        })
         $g.attr(
           'transform',
           (d, i) => 'translate(0,' + i * (barHeight + barMargin) + ')'
@@ -123,9 +125,6 @@ const updateChart = (
             )
           })
           .attr('height', barHeight)
-          .on('click', function (this, e, d) {
-            nodeOnclickHandler(d.ticker.split('-')[1])
-          })
           .style('fill', d => {
             if (d.value > 0) return colorQuantizeScale(max, d.value)
             else if (d.value === 0) return 'gray'

--- a/client/components/Treechart/index.tsx
+++ b/client/components/Treechart/index.tsx
@@ -79,11 +79,10 @@ const updateChart = (
     )
     .join(
       enter => {
-        const $g = enter.append('g')
+        const $g = enter.append('g').on('click', function (this, e, d) {
+          nodeOnclickHandler(d.data.ticker.split('-')[1])
+        })
         $g.append('rect')
-          .on('click', function (this, e, d) {
-            nodeOnclickHandler(d.data.ticker.split('-')[1])
-          })
           .attr('x', function (d) {
             return d.x0
           })


### PR DESCRIPTION
## 개요
- #135 기존에 러닝/트리차트에서 글씨있는부분을 클릭할때는 상세정보 모달창이 나오지 않는점을 수정했습니다.

## 작업사항
- 캔들/트리차트에서 기존 rect에 걸려있었던 onClick이벤트를 상위 g 태그로 이동해서 이벤트 버블링되도록 수정했습니다.

## 생각해볼점

