### PR TITLE
feat : 모바일 캔들차트 줌 이벤트 #59

### DIFF
--- a/client/components/Candlechart/chartController.ts
+++ b/client/components/Candlechart/chartController.ts
@@ -68,6 +68,8 @@ function initCandleChartSVG(
   chartContainer.select('svg#mouse-pointer-UI').attr('pointer-events', 'none')
 }
 
+let prevDistance = -1
+//불가피하게 지역변수 사용.. ㅠㅠ IIFE를 활용한 클로저 사용해보고 싶었으나, 세개의 콜백에 대해서 묶을 수 없어 지역변수 사용함
 export function addEventsToChart(
   svgRef: React.RefObject<SVGSVGElement>,
   optionSetter: React.Dispatch<React.SetStateAction<CandleChartRenderOption>>,
@@ -82,13 +84,58 @@ export function addEventsToChart(
   //margin값도 크기에 맞춰 변수화 시켜야함.
   // xAxis초기값 설정
   // currentPrice초기값 설정
+  function getEuclideanDistance(touches: Touch[]): number {
+    const disX = touches[0].clientX - touches[1].clientX
+    const disY = touches[0].clientY - touches[1].clientY
+    return Math.sqrt(Math.abs(disX * disX) + Math.abs(disY * disY))
+  }
   d3.select<SVGSVGElement, CandleData>('svg#chart-container')
     .call(
       d3
         .drag<SVGSVGElement, CandleData>()
         .on(
+          'start',
+          (event: D3DragEvent<SVGSVGElement, CandleData, unknown>) => {
+            if (
+              event.identifier === 'mouse' ||
+              event.sourceEvent.touches.length !== 2
+            )
+              //마우스거나 (==데스크탑이거나), 2개의 멀티터치가 아니면 아무것도 하지 않음
+              return
+            prevDistance = getEuclideanDistance(event.sourceEvent.touches)
+          }
+        )
+        .on(
           'drag',
           (event: D3DragEvent<SVGSVGElement, CandleData, unknown>) => {
+            if (
+              event.identifier !== 'mouse' &&
+              event.sourceEvent.touches.length == 2
+            ) {
+              //여기는 줌 코드
+              const nowDistance = getEuclideanDistance(
+                event.sourceEvent.touches
+              )
+              if (nowDistance === prevDistance) return
+              const isZoomIn = prevDistance < nowDistance ? 0.5 : -0.5
+              prevDistance = getEuclideanDistance(event.sourceEvent.touches)
+              optionSetter((prev: CandleChartRenderOption) => {
+                const newCandleWidth = Math.min(
+                  Math.max(prev.candleWidth + isZoomIn, prev.minCandleWidth),
+                  prev.maxCandleWidth
+                )
+                const newRenderCandleCount = Math.ceil(
+                  chartAreaXsize / newCandleWidth
+                )
+                return {
+                  ...prev,
+                  renderCandleCount: newRenderCandleCount,
+                  candleWidth: newCandleWidth
+                }
+              })
+              return
+            }
+            //여기는 패닝 코드
             translateXSetter(prev => prev + event.dx)
             handleMouseEvent(
               event.sourceEvent,
@@ -98,6 +145,9 @@ export function addEventsToChart(
             )
           }
         )
+        .on('end', () => {
+          prevDistance = -1
+        })
     )
     .on('wheel', (e: WheelEvent) => {
       e.preventDefault()

--- a/client/components/Candlechart/chartController.ts
+++ b/client/components/Candlechart/chartController.ts
@@ -84,10 +84,11 @@ export function addEventsToChart(
   //margin값도 크기에 맞춰 변수화 시켜야함.
   // xAxis초기값 설정
   // currentPrice초기값 설정
-  function getEuclideanDistance(touches: Touch[]): number {
-    const disX = touches[0].clientX - touches[1].clientX
-    const disY = touches[0].clientY - touches[1].clientY
-    return Math.sqrt(Math.abs(disX * disX) + Math.abs(disY * disY))
+  const getEuclideanDistance = (touches: Touch[]): number => {
+    return Math.sqrt(
+      Math.pow(touches[0].clientX - touches[1].clientX, 2) +
+        Math.pow(touches[0].clientY - touches[1].clientY, 2)
+    )
   }
   d3.select<SVGSVGElement, CandleData>('svg#chart-container')
     .call(


### PR DESCRIPTION
## 개요
- 모바일 캔들차트에서 터치로 줌할 수 있도록 수정함

## 작업사항
- drag 이벤트에 바인딩
- drag 이벤트의 `sourceEvent` 속성 활용하여, 현재 입력방식이 터치인지/마우스인지 판별하여 줌 여부 결정, 터치였다면 두개손가락으로 터치중인지, 아닌지 결정하여 모바일 패닝인지 모바일 줌인지 결정한다.
- 지역변수로 멀티터치하는 두 점사이의 유클리드 거리를 측정하여 전 상태보다 두 점사이의 거리가 줄었는지, 늘었는지를 기준으로 줌인/아웃을 판단한다.

## 생각해볼점
- 더 좋은 방법이 있을지? 지역변수 두고 돌리고 있는데, 클로저라던지,, 뭐 그런방법 사용하면 더 꺨꼼해보일거 같다..
- 클로저 사용해보려고했는데, 한개의 콜백이 아니라 세 개의 콜백함수가 하나의 변수를 공유해야해서.. 난감했다.

## 이미지


https://user-images.githubusercontent.com/60903175/206908537-d89cf4b8-80af-4eb3-a96a-c1f079ba9c63.MOV


