### PR TITLE
fix : 차트 hover시 마우스 오버 이벤트 계속 뜨는 이슈 해결 #146

### DIFF
--- a/client/components/Runningchart/index.tsx
+++ b/client/components/Runningchart/index.tsx
@@ -116,10 +116,8 @@ const updateChart = (
           .on('click', function (e, d) {
             nodeOnclickHandler(d.ticker.split('-')[1])
           }) //this 사용을 위해 함수 선언문 형식 사용
-          .on('mouseover', function () {
-            d3.select(this).style('opacity', '.70')
-          })
           .on('mousemove', (d, i) => {
+            d3.select('g').style('opacity', '.70')
             MainChartHandleMouseEvent(d, setPointerHandler, i, width, height)
           })
           //this 사용을 위해 함수 선언문 형식 사용

--- a/client/components/Treechart/index.tsx
+++ b/client/components/Treechart/index.tsx
@@ -92,10 +92,8 @@ const updateChart = (
             nodeOnclickHandler(d.data.ticker.split('-')[1])
           })
           //this 사용을 위해 함수 선언문 형식 사용
-          .on('mouseover', function (this) {
-            d3.select(this).style('opacity', '.70')
-          })
           .on('mousemove', (d, i) => {
+            d3.select('g').style('opacity', '.70')
             MainChartHandleMouseEvent(
               d,
               setPointerHandler,

--- a/client/hooks/useInterval.ts
+++ b/client/hooks/useInterval.ts
@@ -1,7 +1,8 @@
 import { useEffect, useRef } from 'react'
 
 export default function useInterval(callback: () => unknown, delay: number) {
-  if (!delay) { //딜레이가 undefined, null , 0초인경우 예외처리
+  if (!delay) {
+    //딜레이가 undefined, null , 0초인경우 예외처리
     console.error('정상적인 setInterval 딜레이값이 아닙니다.')
     return
   }

--- a/client/utils/chartManager.ts
+++ b/client/utils/chartManager.ts
@@ -387,17 +387,19 @@ export const convertUnit = (unit: number) => {
 }
 export function MainChartHandleMouseEvent(
   event: MouseEvent,
-  pointerInfoSetter: React.Dispatch<
-    React.SetStateAction<MainChartPointerData>
-  >,
+  pointerInfoSetter: React.Dispatch<React.SetStateAction<MainChartPointerData>>,
   data: CoinRateContentType,
   width: number,
   height: number
 ) {
   if (event.type === 'mousemove') {
     pointerInfoSetter({
-      offsetX: width * 4 > event.offsetX * 5 ? event.offsetX : event.offsetX - 150,
-      offsetY: height / 2 > event.clientY - 100 ? event.clientY - 100 : event.clientY - 250,
+      offsetX:
+        width * 4 > event.offsetX * 5 ? event.offsetX : event.offsetX - 150,
+      offsetY:
+        height / 2 > event.clientY - 100
+          ? event.clientY - 100
+          : event.clientY - 250,
       data: data
     })
   } else {


### PR DESCRIPTION
## 개요
- 차트 hover시 마우스 오버 이벤트 계속 뜨는 이슈 (g태그와 text태그 사이 문제) 해결

## 작업사항
- 마우스 오버 이벤트 제거 및 마우스 무브 이벤트로 통합

## 이미지
- 선택
