### PR TITLE
각종 css style을 css in js 로 통일 및 안쓰는 console.log, 주석처리 제거

### DIFF
--- a/client/components/Candlechart/index.tsx
+++ b/client/components/Candlechart/index.tsx
@@ -99,7 +99,6 @@ export const CandleChart: React.FunctionComponent<CandleChartProps> = props => {
   useEffect(() => {
     const needFetch = checkNeedFetch(props.candleData, option)
     if (needFetch) {
-      // console.log('fetching at ', props.candleData.length, isFetching.current)
       if (!isFetching.current) {
         isFetching.current = true
         getCandleDataArray(
@@ -113,17 +112,13 @@ export const CandleChart: React.FunctionComponent<CandleChartProps> = props => {
             console.error('코인 쿼리 실패, 404에러')
             return
           }
-          // console.log(
-          //   props.candleData[props.candleData.length - 1].candle_date_time_kst
-          // )
-          // console.log(res[0].candle_date_time_kst)
+
           isFetching.current = false
           props.candleDataSetter(prev => {
             const lastDate = new Date(
               prev[prev.length - 1].candle_date_time_kst
             )
             const newDate = new Date(res[0].candle_date_time_kst)
-            // console.log(lastDate, newDate)
             if (newDate <= lastDate) {
               return [...prev, ...res]
             }
@@ -148,33 +143,22 @@ export const CandleChart: React.FunctionComponent<CandleChartProps> = props => {
   }, [pointerInfo, windowSize, option, props])
 
   return (
-    <ChartContainer>
-      <div
-        id="chart"
-        ref={chartContainerRef}
-        style={{
-          display: 'flex',
-          background: '#ffffff',
-          width: '100%',
-          height: '100%'
-        }}
-      >
-        <svg id="chart-container" ref={chartSvg}>
-          <g id="y-axis" />
-          <svg id="x-axis-container">
-            <g id="x-axis" />
-          </svg>
-          <svg id="chart-area" />
-          <svg id="current-price">
-            <line />
-            <rect />
-            <text />
-          </svg>
-          <svg id="mouse-pointer-UI"></svg>
-          <svg id="volume-UI"></svg>
-          <text id="price-info"></text>
+    <ChartContainer ref={chartContainerRef}>
+      <svg id="chart-container" ref={chartSvg}>
+        <g id="y-axis" />
+        <svg id="x-axis-container">
+          <g id="x-axis" />
         </svg>
-      </div>
+        <svg id="chart-area" />
+        <svg id="current-price">
+          <line />
+          <rect />
+          <text />
+        </svg>
+        <svg id="mouse-pointer-UI"></svg>
+        <svg id="volume-UI"></svg>
+        <text id="price-info"></text>
+      </svg>
     </ChartContainer>
   )
 }
@@ -182,6 +166,8 @@ export const CandleChart: React.FunctionComponent<CandleChartProps> = props => {
 const ChartContainer = styled('div')`
   display: flex;
   height: 100%;
+  width: '100%';
+  background: '#ffffff';
   ${props => props.theme.breakpoints.down('tablet')} {
     height: calc(100% - 150px);
   }

--- a/client/components/Candlechart/index.tsx
+++ b/client/components/Candlechart/index.tsx
@@ -166,8 +166,8 @@ export const CandleChart: React.FunctionComponent<CandleChartProps> = props => {
 const ChartContainer = styled('div')`
   display: flex;
   height: 100%;
-  width: '100%';
-  background: '#ffffff';
+  width: 100%;
+  background: #ffffff;
   ${props => props.theme.breakpoints.down('tablet')} {
     height: calc(100% - 150px);
   }

--- a/client/components/CoinSelectController/index.tsx
+++ b/client/components/CoinSelectController/index.tsx
@@ -104,6 +104,7 @@ export default function CoinSelectController({
           return (
             <SelectCoinInnerLayer
               key={index}
+              //coin.name 의존성때문에 styled-component에 포함하지 않습니다.
               style={
                 inputCoinName
                   ? coinDict[inputCoinName]?.includes(coin.name)

--- a/client/components/CoinSelectController/index.tsx
+++ b/client/components/CoinSelectController/index.tsx
@@ -133,7 +133,7 @@ export default function CoinSelectController({
 
 const Container = styled('div')`
   display: flex;
-  background-color: '#ffffff';
+  background-color: #ffffff;
   flex-direction: column;
   width: 100%;
   height: 100%;

--- a/client/components/GNB/SearchInput.tsx
+++ b/client/components/GNB/SearchInput.tsx
@@ -8,6 +8,7 @@ import { matchNameKRwithENG, validateInputName } from '@/utils/inputBarManager'
 import { MyAppContext } from '../../pages/_app'
 import { useMediaQuery } from '@mui/material'
 import theme from '@/styles/theme'
+import { styled } from '@mui/system'
 
 export default function SearchInput() {
   const data = React.useContext(MyAppContext)
@@ -57,8 +58,7 @@ export default function SearchInput() {
               },
               placeholder: '검색어를 입력하세요',
               endAdornment: (
-                <a
-                  style={{ display: 'flex', alignItems: 'center' }}
+                <StyledSearchIcon
                   href=""
                   onClick={e => {
                     e.preventDefault()
@@ -66,7 +66,7 @@ export default function SearchInput() {
                   }}
                 >
                   <SearchIcon sx={{ opacity: 0.2 }} />
-                </a>
+                </StyledSearchIcon>
               )
             }}
           />
@@ -75,3 +75,7 @@ export default function SearchInput() {
     </Stack>
   )
 }
+const StyledSearchIcon = styled('a')`
+  display: 'flex';
+  align-items: 'center';
+`

--- a/client/components/GNB/SearchInput.tsx
+++ b/client/components/GNB/SearchInput.tsx
@@ -76,6 +76,6 @@ export default function SearchInput() {
   )
 }
 const StyledSearchIcon = styled('a')`
-  display: 'flex';
-  align-items: 'center';
+  display: flex;
+  align-items: center;
 `

--- a/client/components/GNB/index.tsx
+++ b/client/components/GNB/index.tsx
@@ -9,19 +9,11 @@ export default function GNB() {
   const isMobile = useMediaQuery(theme.breakpoints.down('tablet'))
   return (
     <GNBContainer>
-      <Container
-        maxWidth="max"
-        id="GNBcontainer"
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          paddingLeft: '16px'
-        }}
-      >
+      <Container maxWidth="max" id="GNBcontainer" sx={ContainerStyle}>
         {isMobile ? (
           <Link href="/">
             <Image
-              style={{ paddingRight: '16px' }}
+              style={MobileImageStyle}
               src="/logo-only-white.svg"
               alt=""
               width={40}
@@ -31,7 +23,7 @@ export default function GNB() {
         ) : (
           <Link href="/">
             <Image
-              style={{ margin: '0px 16px 0px 32px' }}
+              style={DesktopImageStyle}
               src="/logo-white.svg"
               alt=""
               width={200}
@@ -44,6 +36,13 @@ export default function GNB() {
     </GNBContainer>
   )
 }
+const ContainerStyle = {
+  display: 'flex',
+  alignItems: 'center',
+  paddingLeft: '16px'
+}
+const MobileImageStyle = { paddingRight: '16px' }
+const DesktopImageStyle = { margin: '0px 16px 0px 32px' }
 
 const GNBContainer = styled('div')`
   position: fixed;

--- a/client/components/LinkButton/index.tsx
+++ b/client/components/LinkButton/index.tsx
@@ -6,18 +6,17 @@ interface ChartButtonProps {
   content: string
   style?: object
 }
+const LinkStyle = { textDecoration: 'none', width: '100%', marginTop: '8px' }
+
 export default function Chartbutton({
   goto = '/',
   content = 'default',
   style = {}
 }: ChartButtonProps) {
   return (
-    <Link
-      href={goto}
-      style={{ textDecoration: 'none', width: '100%', marginTop: '8px' }}
-    >
+    <Link href={goto} style={LinkStyle}>
       <Button
-        style={{
+        sx={{
           width: '100%',
 
           ...style

--- a/client/components/Modal/index.tsx
+++ b/client/components/Modal/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import Box from '@mui/material/Box'
 import Modal from '@mui/material/Modal'
 
-const style = {
+const boxStyle = {
   position: 'absolute',
   top: '50%',
   left: '50%',
@@ -33,7 +33,7 @@ export default function MuiModal({
         aria-labelledby="modal-modal-title"
         aria-describedby="modal-modal-description"
       >
-        <Box sx={style}>{children}</Box>
+        <Box sx={boxStyle}>{children}</Box>
       </Modal>
     </div>
   )

--- a/client/components/Runningchart/index.tsx
+++ b/client/components/Runningchart/index.tsx
@@ -13,6 +13,7 @@ import {
 import { convertUnit } from '@/utils/chartManager'
 import { DEFAULT_RUNNING_POINTER_DATA } from '@/constants/ChartConstants'
 import ChartTagController from '../ChartTagController'
+import { styled } from '@mui/system'
 
 //------------------------------interface------------------------------
 interface RunningChartProps {
@@ -46,10 +47,6 @@ const updateChart = (
   nodeOnclickHandler: (market: string) => void,
   setPointerHandler: React.Dispatch<React.SetStateAction<MainChartPointerData>>
 ) => {
-  // if (!data || !svgRef) {
-  //   return
-  // }
-
   //ArrayDataValue : 기존 Object<object>이던 data를 data.value, 즉 실시간변동 퍼센테이지 값만 추출해서 Array<object>로 변경
   const ArrayDataValue: CoinRateContentType[] = [
     ...Object.values<CoinRateContentType>(data)
@@ -320,21 +317,19 @@ export const RunningChart: React.FunctionComponent<RunningChartProps> = ({
     setchangeRate(newCoinData)
   }, [data, Market, coinRate])
   return (
-    <div
-      id="chart"
-      ref={chartContainerRef}
-      style={{
-        display: 'flex',
-        width: '100%',
-        background: '#ffffff',
-        height: '100%',
-        overflow: 'auto'
-      }}
-    >
+    <ChartContainer ref={chartContainerRef}>
       <svg id="chart-container" ref={chartSvg}>
         <svg id="running-chart" />
       </svg>
       <ChartTagController pointerInfo={pointerInfo} />
-    </div>
+    </ChartContainer>
   )
 }
+
+const ChartContainer = styled('div')`
+  display: 'flex';
+  width: '100%';
+  background: '#ffffff';
+  height: '100%';
+  overflow: 'auto';
+`

--- a/client/components/Runningchart/index.tsx
+++ b/client/components/Runningchart/index.tsx
@@ -13,7 +13,7 @@ import {
 import { convertUnit } from '@/utils/chartManager'
 import { DEFAULT_RUNNING_POINTER_DATA } from '@/constants/ChartConstants'
 import ChartTagController from '../ChartTagController'
-import { styled } from '@mui/system'
+import { styled } from '@mui/material'
 
 //------------------------------interface------------------------------
 interface RunningChartProps {
@@ -325,11 +325,10 @@ export const RunningChart: React.FunctionComponent<RunningChartProps> = ({
     </ChartContainer>
   )
 }
-
 const ChartContainer = styled('div')`
-  display: 'flex';
-  width: '100%';
-  background: '#ffffff';
-  height: '100%';
-  overflow: 'auto';
+  display: flex;
+  width: 100%;
+  background: #ffffff;
+  height: 100%;
+  overflow: auto;
 `

--- a/client/components/Treechart/index.tsx
+++ b/client/components/Treechart/index.tsx
@@ -327,8 +327,8 @@ export default function TreeChart({
 }
 
 const ChartContainer = styled('div')`
-  display: 'flex';
-  width: '100%';
-  height: '100%';
-  background: '#ffffff';
+  display: flex;
+  width: 100%;
+  height: 100%;
+  background: #ffffff;
 `

--- a/client/components/Treechart/index.tsx
+++ b/client/components/Treechart/index.tsx
@@ -11,6 +11,7 @@ import { throttle } from 'lodash'
 import { convertUnit, MainChartHandleMouseEvent } from '@/utils/chartManager'
 import ChartTagController from '../ChartTagController'
 import { DEFAULT_RUNNING_POINTER_DATA } from '@/constants/ChartConstants'
+import { styled } from '@mui/system'
 
 const updateChart = (
   svgRef: React.RefObject<SVGSVGElement>,
@@ -316,19 +317,18 @@ export default function TreeChart({
     setPointerInfo(DEFAULT_RUNNING_POINTER_DATA)
   }, [changeRate, width, height, selectedSort, modalOpenHandler])
   return (
-    <div
-      style={{
-        display: 'flex',
-        width: '100%',
-        height: '100%',
-        background: '#ffffff'
-      }}
-      ref={chartContainerSvg}
-    >
+    <ChartContainer ref={chartContainerSvg}>
       <svg id="tree-chart" ref={chartSvg}>
         <svg id="chart-area"></svg>
       </svg>
       <ChartTagController pointerInfo={pointerInfo} />
-    </div>
+    </ChartContainer>
   )
 }
+
+const ChartContainer = styled('div')`
+  display: 'flex';
+  width: '100%';
+  height: '100%';
+  background: '#ffffff';
+`

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -91,7 +91,7 @@ export default function Home() {
                 <LinkButton
                   goto={`detail/${selectedMarket}`}
                   content={`${selectedMarket}(으)로 바로가기`}
-                  style={{ position: 'absolute', bottom: 0 }}
+                  style={LinkButtonStyle}
                 />
               </TabBox>
             </TabContainer>
@@ -189,3 +189,4 @@ const ChartContainer = styled(Box)`
   height: 100%;
   flex-direction: column;
 `
+const LinkButtonStyle = { position: 'absolute', bottom: 0 }

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -167,7 +167,7 @@ const SideBarContainer = styled(Box)`
   display: flex;
   flex-direction: column;
   box-sizing: border-box;
-  background-color: '#ffffff';
+  background-color: #ffffff;
   align-items: center;
   min-width: 330px;
   max-width: 330px;
@@ -182,7 +182,7 @@ const SideBarContainer = styled(Box)`
 `
 const ChartContainer = styled(Box)`
   display: flex;
-  background: '#ffffff';
+  background: #ffffff;
   box-sizing: content-box; //얘가 차트 크기를 고정해준다. 이유는 아직 모르겠다..
   min-width: 300px;
   width: 100%;


### PR DESCRIPTION
## 개요
#145 
- 각종 css style을 css in js 로 통일 및 안쓰는 console.log, 주석처리 제거 했습니다.

## 작업사항
- 기본 html 태그들에 style이 props로 있는 경우 css in js 형식으로 다 변경했습니다.
- mui 컴포넌트의 props로 style이 있는경우에는 커스텀 컴포넌트를 만들기 어려워서 그냥 style 객체값을 변수로 만들어줬습니다. ex) `<Link style={linkStyle}>`
- 가끔보이는 console.log나 주석처리를 조금 없앴습니다.

## 생각해볼점
일단 검색으로 다 처리하긴했지만 추후에 미처 수정못한부분이 생길수도 있고, 나중에 코드를 짜면서 새롭게 생길수도있습니다 모두 눈에 보일때마다 조금씩 처리 부탁드려요