### PR TITLE
fix: 초기 주봉 데이터 200개 미만 오류수정 #157

### DIFF
--- a/client/components/Candlechart/chartController.ts
+++ b/client/components/Candlechart/chartController.ts
@@ -163,13 +163,21 @@ export function addEventsToChart(
             chartAreaXsize / newCandleWidth
           )
           if (prev.maxDataLength !== Infinity) {
-            const newMaxRenderStartDataIndex =
+            const newMaxRenderStartDataIndex = Math.max(
+              0,
               prev.maxDataLength - newRenderCandleCount + 1
+            )
             return {
               ...prev,
-              renderCandleCount: newRenderCandleCount,
-              candleWidth: newCandleWidth,
               maxRenderStartDataIndex: newMaxRenderStartDataIndex,
+              renderCandleCount:
+                newMaxRenderStartDataIndex === 0
+                  ? prev.renderCandleCount
+                  : newRenderCandleCount,
+              candleWidth:
+                newMaxRenderStartDataIndex === 0
+                  ? prev.candleWidth
+                  : newCandleWidth,
               renderStartDataIndex: Math.min(
                 prev.renderStartDataIndex,
                 newMaxRenderStartDataIndex


### PR DESCRIPTION
## 개요
- 초기 주봉데이터가 200개가 되지않는 코인들에 대한 에러처리

## 작업사항
- 기존에는 maxDataLength가 정해지면 maxDataLength와 candleCount를 이용해 maxRenderStartDataIndex를 계산하였다.  

  계산된 maxRenderStartDataIndex보다 renderStartDataIndex가 항상 작도록 코드를 작성하였는데, 주봉의 갯수가 200개가 되지않는 코인들은 maxDataLength - CandleCount가 음수가 되는 경우가 발생하였고 계산된 maxRenderStartDataIndex보다 작은 renderStartDataIndex로 변경하면서 candleData의 -2번째 인덱스의 요소에 접근하는 오류가 발생하였다.  

  maxRenderStartDataIndex가 음수가 될경우 0으로 변경하도록 코드를 수정하였고, maxRenderStartDataIndex가 0일 경우 candleWidth와 candleCount를 변경하지 않도록 수정하였다.

## 이미지

### 작업이전
![Dec-13-2022 02-03-13](https://user-images.githubusercontent.com/70005144/207107910-d4d7128c-c904-4675-b109-4d75a1a17bb6.gif)

### 작업이후
![Dec-13-2022 02-03-41](https://user-images.githubusercontent.com/70005144/207108125-32491d90-b6ef-43d6-9095-3a18454b2b1a.gif)


PR에 해당하는 이슈는 우측의 Development에서 등록해주세요!!
