### PR TITLE
Issue#160/mobile zoom closure

### DIFF
--- a/client/components/Candlechart/index.tsx
+++ b/client/components/Candlechart/index.tsx
@@ -1,4 +1,11 @@
-import { useRef, useState, useEffect } from 'react'
+import {
+  useRef,
+  useState,
+  useEffect,
+  Dispatch,
+  SetStateAction,
+  FunctionComponent
+} from 'react'
 import {
   CandleChartOption,
   CandleChartRenderOption,
@@ -26,10 +33,10 @@ import {
 export interface CandleChartProps {
   chartOption: CandleChartOption
   candleData: CandleData[]
-  candleDataSetter: React.Dispatch<React.SetStateAction<CandleData[]>>
+  candleDataSetter: Dispatch<SetStateAction<CandleData[]>>
 }
 
-export const CandleChart: React.FunctionComponent<CandleChartProps> = props => {
+export const CandleChart: FunctionComponent<CandleChartProps> = props => {
   const chartSvg = useRef<SVGSVGElement>(null)
   const chartContainerRef = useRef<HTMLDivElement>(null)
   const refElementSize = useRefElementSize(chartContainerRef)

--- a/client/components/Candlechart/mobileTouchEventClosure.ts
+++ b/client/components/Candlechart/mobileTouchEventClosure.ts
@@ -1,0 +1,65 @@
+import {
+  CandleData,
+  CandleChartRenderOption,
+  PointerData
+} from '@/types/ChartTypes'
+import { handleMouseEvent } from '@/utils/chartManager'
+import { D3DragEvent } from 'd3'
+import { Dispatch, SetStateAction } from 'react'
+
+const getEuclideanDistance = (touches: Touch[]): number => {
+  return Math.sqrt(
+    Math.pow(touches[0].clientX - touches[1].clientX, 2) +
+      Math.pow(touches[0].clientY - touches[1].clientY, 2)
+  )
+}
+
+export const mobileEventClosure = (
+  optionSetter: Dispatch<SetStateAction<CandleChartRenderOption>>,
+  translateXSetter: Dispatch<SetStateAction<number>>,
+  pointerPositionSetter: Dispatch<SetStateAction<PointerData>>,
+  chartAreaXsize: number,
+  chartAreaYsize: number
+) => {
+  let prevDistance = -1
+  const start = (event: D3DragEvent<SVGSVGElement, CandleData, unknown>) => {
+    if (event.identifier === 'mouse' || event.sourceEvent.touches.length !== 2)
+      //마우스거나 (==데스크탑이거나), 2개의 멀티터치가 아니면 아무것도 하지 않음
+      return
+    prevDistance = getEuclideanDistance(event.sourceEvent.touches)
+  }
+  const drag = (event: D3DragEvent<SVGSVGElement, CandleData, unknown>) => {
+    if (event.identifier !== 'mouse' && event.sourceEvent.touches.length == 2) {
+      //여기는 줌 코드
+      const nowDistance = getEuclideanDistance(event.sourceEvent.touches)
+      if (nowDistance === prevDistance) return
+      const isZoomIn = prevDistance < nowDistance ? 0.5 : -0.5
+      prevDistance = getEuclideanDistance(event.sourceEvent.touches)
+      optionSetter((prev: CandleChartRenderOption) => {
+        const newCandleWidth = Math.min(
+          Math.max(prev.candleWidth + isZoomIn, prev.minCandleWidth),
+          prev.maxCandleWidth
+        )
+        const newRenderCandleCount = Math.ceil(chartAreaXsize / newCandleWidth)
+        return {
+          ...prev,
+          renderCandleCount: newRenderCandleCount,
+          candleWidth: newCandleWidth
+        }
+      })
+      return
+    }
+    //여기는 패닝 코드
+    translateXSetter(prev => prev + event.dx)
+    handleMouseEvent(
+      event.sourceEvent,
+      pointerPositionSetter,
+      chartAreaXsize,
+      chartAreaYsize
+    )
+  }
+  const end = () => {
+    prevDistance = -1
+  }
+  return [start, drag, end]
+}

--- a/client/components/CoinSelectController/SearchCoin.tsx
+++ b/client/components/CoinSelectController/SearchCoin.tsx
@@ -1,8 +1,9 @@
 import TextField from '@mui/material/TextField'
 import { debounce } from 'lodash'
+import { Dispatch, SetStateAction } from 'react'
 
 interface SearchCoinProps {
-  setInputCoinNameSetter: React.Dispatch<React.SetStateAction<string>>
+  setInputCoinNameSetter: Dispatch<SetStateAction<string>>
 }
 
 export default function SearchCoin({

--- a/client/components/CoinSelectController/index.tsx
+++ b/client/components/CoinSelectController/index.tsx
@@ -1,6 +1,13 @@
 import { styled } from '@mui/material/styles'
 import Checkbox from '@mui/material/Checkbox'
-import { useContext, useEffect, useState } from 'react'
+import {
+  ChangeEvent,
+  Dispatch,
+  SetStateAction,
+  useContext,
+  useEffect,
+  useState
+} from 'react'
 import Image from 'next/image'
 import { MarketCapInfo } from '@/types/CoinDataTypes'
 import SearchCoin from './SearchCoin'
@@ -15,7 +22,7 @@ interface CoinChecked {
   [key: string]: boolean
 }
 interface CoinSelectControllerProps {
-  selectedCoinListSetter: React.Dispatch<React.SetStateAction<string[]>>
+  selectedCoinListSetter: Dispatch<SetStateAction<string[]>>
   tabLabelInfo?: string
 }
 
@@ -58,7 +65,7 @@ export default function CoinSelectController({
     )
   }, [checked])
 
-  const coinCheckAll = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const coinCheckAll = (event: ChangeEvent<HTMLInputElement>) => {
     if (checked['all']) {
       for (const coin in checked) {
         checked[coin] = event.target.checked
@@ -80,7 +87,7 @@ export default function CoinSelectController({
     })
   }
 
-  const coinCheck = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const coinCheck = (event: ChangeEvent<HTMLInputElement>) => {
     setChecked({
       ...checked,
       [event.target.name]: event.target.checked

--- a/client/components/RealTimeCoinPrice/index.tsx
+++ b/client/components/RealTimeCoinPrice/index.tsx
@@ -3,7 +3,7 @@ import { TabProps } from '@/components/TabContainer'
 import Image from 'next/image'
 import { CoinPrice } from '@/types/CoinPriceTypes'
 import Link from 'next/link'
-import { useState } from 'react'
+import { useState, FunctionComponent } from 'react'
 //코인 실시간 정보
 
 export const sortTypeArr = [
@@ -78,9 +78,7 @@ interface CoinPriceTabProps {
   coinPrice: CoinPrice
 }
 
-const CoinPriceTab: React.FunctionComponent<CoinPriceTabProps> = ({
-  coinPrice
-}) => {
+const CoinPriceTab: FunctionComponent<CoinPriceTabProps> = ({ coinPrice }) => {
   const theme = useTheme()
   const isMinus = coinPrice.signed_change_price <= 0
   const textColor =

--- a/client/components/Runningchart/index.tsx
+++ b/client/components/Runningchart/index.tsx
@@ -1,5 +1,13 @@
 import * as d3 from 'd3'
-import { useState, useEffect, useRef } from 'react'
+import {
+  useState,
+  useEffect,
+  useRef,
+  RefObject,
+  FunctionComponent,
+  SetStateAction,
+  Dispatch
+} from 'react'
 import {
   CoinRateContentType,
   CoinRateType,
@@ -31,7 +39,7 @@ interface RunningChartProps {
 
 //------------------------------setChartContainerSize------------------------------
 const setChartContainerSize = (
-  svgRef: React.RefObject<SVGSVGElement>,
+  svgRef: RefObject<SVGSVGElement>,
   width: number,
   height: number
 ) => {
@@ -43,14 +51,14 @@ const setChartContainerSize = (
 //------------------------------updateChart------------------------------
 const updateChart = (
   durationPeriod: number,
-  svgRef: React.RefObject<SVGSVGElement>,
+  svgRef: RefObject<SVGSVGElement>,
   data: CoinRateType,
   width: number,
   height: number,
   candleCount: number,
   selectedSort: string,
   nodeOnclickHandler: (market: string) => void,
-  setPointerHandler: React.Dispatch<React.SetStateAction<MainChartPointerData>>,
+  setPointerHandler: Dispatch<SetStateAction<MainChartPointerData>>,
   isMobile: boolean
 ) => {
   //ArrayDataValue : 기존 Object<object>이던 data를 data.value, 즉 실시간변동 퍼센테이지 값만 추출해서 Array<object>로 변경
@@ -300,7 +308,7 @@ const updateChart = (
     )
 }
 //------------------------------Component------------------------------
-export const RunningChart: React.FunctionComponent<RunningChartProps> = ({
+export const RunningChart: FunctionComponent<RunningChartProps> = ({
   durationPeriod = 500,
   data,
   Market,

--- a/client/components/SwiperableDrawer/index.tsx
+++ b/client/components/SwiperableDrawer/index.tsx
@@ -22,8 +22,6 @@ export default function SwipeableTemporaryDrawer({
   setIsDrawerOpened,
   children
 }: SwipeableTemporaryDrawerProps) {
-  // const [isDrawerOpened, setIsDrawerOpened] = React.useState(false)
-
   const toggleDrawer =
     (open: boolean) => (event: KeyboardEvent | MouseEvent) => {
       if (

--- a/client/components/TabContainer/index.tsx
+++ b/client/components/TabContainer/index.tsx
@@ -7,7 +7,8 @@ import {
   SetStateAction,
   ReactNode,
   Children,
-  isValidElement
+  isValidElement,
+  SyntheticEvent
 } from 'react'
 
 export interface TabProps {
@@ -52,8 +53,7 @@ export default function TabContainer({
   setSelectedTab,
   children
 }: TabContainerProps) {
-  // const [selectedTab, setSelectedTab] = React.useState<number>(0)
-  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+  const handleChange = (event: SyntheticEvent, newValue: number) => {
     setSelectedTab(newValue)
   }
   return (

--- a/client/components/Treechart/index.tsx
+++ b/client/components/Treechart/index.tsx
@@ -1,5 +1,12 @@
 import * as d3 from 'd3'
-import { useState, useEffect, useRef } from 'react'
+import {
+  useState,
+  useEffect,
+  useRef,
+  SetStateAction,
+  Dispatch,
+  RefObject
+} from 'react'
 import { useRefElementSize } from '@/hooks/useRefElementSize'
 import {
   CoinRateType,
@@ -7,20 +14,19 @@ import {
   MainChartPointerData
 } from '@/types/ChartTypes'
 import { colorQuantizeScale } from '@/utils/chartManager'
-import { throttle } from 'lodash'
 import { convertUnit, MainChartHandleMouseEvent } from '@/utils/chartManager'
 import ChartTagController from '../ChartTagController'
 import { DEFAULT_RUNNING_POINTER_DATA } from '@/constants/ChartConstants'
 import { styled } from '@mui/system'
 
 const updateChart = (
-  svgRef: React.RefObject<SVGSVGElement>,
+  svgRef: RefObject<SVGSVGElement>,
   data: CoinRateContentType[],
   width: number,
   height: number,
   selectedSort: string,
   nodeOnclickHandler: (market: string) => void,
-  setPointerHandler: React.Dispatch<React.SetStateAction<MainChartPointerData>>,
+  setPointerHandler: Dispatch<SetStateAction<MainChartPointerData>>,
   isMobile: boolean
 ) => {
   if (!svgRef.current) return
@@ -252,7 +258,7 @@ const updateChart = (
 }
 
 const initChart = (
-  svgRef: React.RefObject<SVGSVGElement>,
+  svgRef: RefObject<SVGSVGElement>,
   width: number,
   height: number
 ) => {

--- a/client/hooks/useRefElementSize.ts
+++ b/client/hooks/useRefElementSize.ts
@@ -2,7 +2,7 @@ import {
   CHART_X_AXIS_MARGIN,
   CHART_Y_AXIS_MARGIN
 } from '@/constants/ChartConstants'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, RefObject } from 'react'
 
 export interface RefElementSize {
   width: number
@@ -14,7 +14,7 @@ export interface RefElementSize {
  * @param ref width와 height를 얻길 원하는 html 태그의 ref
  * @returns  width와 height의 변화하는 상태값
  */
-export function useRefElementSize(ref: React.RefObject<Element>) {
+export function useRefElementSize(ref: RefObject<Element>) {
   const [refElementSize, setRefElementSize] = useState<RefElementSize>({
     width: CHART_Y_AXIS_MARGIN,
     height: CHART_X_AXIS_MARGIN

--- a/client/hooks/useUserAgent.ts
+++ b/client/hooks/useUserAgent.ts
@@ -1,9 +1,9 @@
-import React from 'react'
+import { useState, useEffect } from 'react'
 
 export default function useDeviceDetect() {
-  const [isMobileDevice, setMobile] = React.useState(false)
+  const [isMobileDevice, setMobile] = useState(false)
 
-  React.useEffect(() => {
+  useEffect(() => {
     const userAgent =
       typeof window.navigator === 'undefined' ? '' : navigator.userAgent
     const mobile = Boolean(

--- a/client/pages/_document.tsx
+++ b/client/pages/_document.tsx
@@ -11,7 +11,7 @@ import theme from '../style/theme'
 import createEmotionCache from '../style/createEmotionCache'
 import { EmotionCache } from '@emotion/react'
 import { AppType } from 'next/app'
-import { ReactNode } from 'react'
+import { ComponentType, ReactNode } from 'react'
 
 interface DocumentProps extends DocumentInitialProps {
   emotionStyleTags: ReactNode[]
@@ -90,7 +90,7 @@ MyDocument.getInitialProps = async (
   ctx.renderPage = () =>
     originalRenderPage({
       enhanceApp: (
-        App: AppType | React.ComponentType<{ emotionCache: EmotionCache }>
+        App: AppType | ComponentType<{ emotionCache: EmotionCache }>
       ) =>
         function EnhanceApp(props) {
           return <App emotionCache={cache} {...props} />

--- a/client/utils/chartManager.ts
+++ b/client/utils/chartManager.ts
@@ -24,7 +24,8 @@ import {
 import * as d3 from 'd3'
 import { makeDate } from './dateManager'
 import { blueColorScale, redColorScale } from '@/styles/colorScale'
-import { CoinRateType, CoinRateContentType } from '@/types/ChartTypes'
+import { CoinRateContentType } from '@/types/ChartTypes'
+import { Dispatch, SetStateAction } from 'react'
 
 export function getVolumeHeightScale(
   data: CandleData[],
@@ -315,7 +316,7 @@ function transPointerInfoToArray(pointerInfo: PointerData) {
 // 마우스 이벤트 핸들러 포인터의 위치를 파악하고 pointerPosition을 갱신한다.
 export function handleMouseEvent(
   event: MouseEvent,
-  pointerPositionSetter: React.Dispatch<React.SetStateAction<PointerData>>,
+  pointerPositionSetter: Dispatch<SetStateAction<PointerData>>,
   chartAreaXsize: number,
   chartAreaYsize: number
 ) {
@@ -391,7 +392,7 @@ export const convertUnit = (unit: number) => {
 }
 export function MainChartHandleMouseEvent(
   event: MouseEvent,
-  pointerInfoSetter: React.Dispatch<React.SetStateAction<MainChartPointerData>>,
+  pointerInfoSetter: Dispatch<SetStateAction<MainChartPointerData>>,
   data: CoinRateContentType,
   width: number,
   height: number


### PR DESCRIPTION
## 개요
- 지역변수를 조작하던 모바일 줌 이벤트를 클로저를 활용하게 리팩터
## 작업사항
- 리액트 named 작업 안된 부분 마무리 처리
- 모바일 zoom 이벤트 클로저활용

## 생각해볼점
- 매 init마다 d3 drag에 이벤트가 unbind되면서, 클로저가 리턴하는 함수들이 언바인드 -> 클로저 내부 `prevdistance` 넘버 변수도 GC되는것으로 추정
    - performance 개발자도구로 확인결과, 괄목할만한 메모리 유출? 현상은 발견 x
- `useRealtimeUpbitData`의 소켓변수도, 클로저로 묶을수 있을지도
