### PR TITLE
Issue#162/main socket refactoring

### DIFF
--- a/client/components/Candlechart/chartController.ts
+++ b/client/components/Candlechart/chartController.ts
@@ -378,8 +378,10 @@ function placeCandleRect(
   $g.append('rect')
     .classed('candleRect', true)
     .attr('width', candleWidth * 0.6)
-    .attr('height', d =>
-      Math.abs(yAxisScale(d.trade_price) - yAxisScale(d.opening_price))
+    .attr(
+      'height',
+      d =>
+        Math.abs(yAxisScale(d.trade_price) - yAxisScale(d.opening_price)) || 0.1
     )
     .attr(
       'x',

--- a/client/components/Candlechart/index.tsx
+++ b/client/components/Candlechart/index.tsx
@@ -161,7 +161,13 @@ export const CandleChart: FunctionComponent<CandleChartProps> = props => {
   }, [props, option, refElementSize])
 
   useEffect(() => {
-    updatePointerUI(pointerInfo, option, props.candleData, refElementSize)
+    updatePointerUI(
+      pointerInfo,
+      option,
+      props.candleData,
+      refElementSize,
+      props.chartOption.candlePeriod
+    )
   }, [pointerInfo, refElementSize, option, props])
 
   return (

--- a/client/components/RealTimeCoinPrice/index.tsx
+++ b/client/components/RealTimeCoinPrice/index.tsx
@@ -184,7 +184,7 @@ const Header = styled('div')`
       flex: 1;
     }
 
-    & > div {
+    & > div:not(:first-of-type) {
       cursor: pointer;
       :hover {
         background-color: ${props => props.theme.palette.primary.main};

--- a/client/components/Runningchart/index.tsx
+++ b/client/components/Runningchart/index.tsx
@@ -319,7 +319,6 @@ export const RunningChart: FunctionComponent<RunningChartProps> = ({
   const chartContainerRef = useRef<HTMLDivElement>(null)
   const chartSvg = useRef(null)
   const { width, height } = useRefElementSize(chartContainerRef)
-  const [coinRate, setCoinRate] = useState<CoinRateType>(data) //coin의 등락률 값, 모든 코인 값 보유
   const [changeRate, setchangeRate] = useState<CoinRateType>({}) //선택된 코인 값만 보유
   const [pointerInfo, setPointerInfo] = useState<MainChartPointerData>(
     DEFAULT_RUNNING_POINTER_DATA
@@ -350,13 +349,13 @@ export const RunningChart: FunctionComponent<RunningChartProps> = ({
     isMobile
   ]) // 창크기에 따른 차트크기 조절
   useEffect(() => {
-    if (!coinRate || !Market[0]) return
+    if (!data || !Market[0]) return
     const newCoinData: CoinRateType = {}
     for (const tick of Market) {
-      newCoinData['KRW-' + tick] = coinRate['KRW-' + tick]
+      newCoinData['KRW-' + tick] = data['KRW-' + tick]
     }
     setchangeRate(newCoinData)
-  }, [data, Market, coinRate])
+  }, [data, Market])
   return (
     <ChartContainer ref={chartContainerRef}>
       <svg id="chart-container" ref={chartSvg}>

--- a/client/hooks/useInterval.ts
+++ b/client/hooks/useInterval.ts
@@ -1,11 +1,6 @@
 import { useEffect, useRef } from 'react'
 
 export default function useInterval(callback: () => unknown, delay: number) {
-  // if (!delay) {
-  //   //딜레이가 undefined, null , 0초인경우 예외처리
-  //   console.error('정상적인 setInterval 딜레이값이 아닙니다.')
-  //   return
-  // }
   const savedCallback = useRef(callback) // 최근에 들어온 callback을 저장할 ref를 하나 만든다.
 
   useEffect(() => {

--- a/client/hooks/useRealTimeCoinListData.ts
+++ b/client/hooks/useRealTimeCoinListData.ts
@@ -1,10 +1,11 @@
-import { UpdateTreeData } from '@/components/Treechart/GetCoinData'
 import { CoinRateContentType, CoinRateType } from '@/types/ChartTypes'
 import { MarketCapInfo } from '@/types/CoinDataTypes'
-import { useState } from 'react'
+import { SocketTickerData } from '@/types/CoinPriceTypes'
+import { useRef, useState, useEffect } from 'react'
 import useInterval from './useInterval'
 
 const COIN_INTERVAL_RATE = 5000
+let socket: WebSocket | undefined
 const getInitData = (data: MarketCapInfo[]): CoinRateType => {
   //initData
   const initData: CoinRateType = {}
@@ -32,13 +33,100 @@ const getInitData = (data: MarketCapInfo[]): CoinRateType => {
 }
 export function useRealTimeCoinListData(data: MarketCapInfo[]) {
   const [coinData, setCoinData] = useState<CoinRateType>(getInitData(data))
+  const coinDataStoreRef = useRef(coinDataStoreGenerator())
 
   useInterval(() => {
-    async function update() {
-      const updatedCoinRate = await UpdateTreeData(coinData)
-      setCoinData(updatedCoinRate)
-    }
-    update()
+    const storedCoinData = coinDataStoreRef.current.getCoinData()
+    setCoinData(prev => getNewCoinData(prev, storedCoinData))
   }, COIN_INTERVAL_RATE)
+
+  useEffect(() => {
+    connectWS(data, coinDataStoreRef.current.setCoinData)
+    return () => {
+      closeWS()
+    }
+  }, [])
   return coinData
+}
+
+function connectWS(
+  data: MarketCapInfo[],
+  setCoinData: (tickData: SocketTickerData) => void
+) {
+  if (socket !== undefined) {
+    socket.close()
+  }
+
+  socket = new WebSocket('wss://api.upbit.com/websocket/v1')
+  socket.binaryType = 'arraybuffer'
+
+  socket.onopen = function () {
+    const markets = data.map(coinData => 'KRW-' + coinData.name).join(',')
+    filterRequest(`[{"ticket":"test"},{"type":"ticker","codes":[${markets}]}]`)
+  }
+  socket.onclose = function () {
+    socket = undefined
+  }
+  socket.onmessage = function (e) {
+    const enc = new TextDecoder('utf-8')
+    const arr = new Uint8Array(e.data)
+    const str_d = enc.decode(arr)
+    const d = JSON.parse(str_d)
+    setCoinData(d)
+  }
+}
+
+// 웹소켓 연결 해제
+function closeWS() {
+  if (socket !== undefined) {
+    socket.close()
+    socket = undefined
+  }
+}
+
+// 웹소켓 요청
+function filterRequest(filter: string) {
+  if (socket == undefined) {
+    return
+  }
+  socket.send(filter)
+}
+
+interface CoinDataStore {
+  [key: string]: Partial<CoinRateContentType>
+}
+
+function coinDataStoreGenerator() {
+  let coinDataStore: CoinDataStore = {}
+  return {
+    setCoinData: (newTickerData: SocketTickerData) => {
+      coinDataStore[newTickerData.code] = transToCoinData(newTickerData)
+      return
+    },
+    getCoinData: () => {
+      const storedCoinData: CoinDataStore = { ...coinDataStore }
+      coinDataStore = {}
+      return storedCoinData
+    }
+  }
+}
+
+function transToCoinData(
+  newTickerData: SocketTickerData
+): Partial<CoinRateContentType> {
+  return {
+    acc_trade_price_24h: newTickerData.acc_trade_price_24h,
+    value: Number((newTickerData.signed_change_rate * 100).toFixed(2))
+  }
+}
+
+function getNewCoinData(
+  prevData: CoinRateType,
+  storedPrice: CoinDataStore
+): CoinRateType {
+  const newCoinData = { ...prevData }
+  Object.keys(storedPrice).forEach(code => {
+    newCoinData[code] = { ...newCoinData[code], ...storedPrice[code] }
+  })
+  return newCoinData
 }

--- a/client/hooks/useRealTimeUpbitData.ts
+++ b/client/hooks/useRealTimeUpbitData.ts
@@ -80,7 +80,7 @@ export const useRealTimeUpbitData = (
   return [realtimeCandleData, setRealtimeCandleData, realtimePriceInfo] //socket을 state해서 같이 뺀다. 변화감지 (끊길때) -> ui표시..
 }
 
-export function connectWS(priceInfo: CoinPriceObj) {
+function connectWS(priceInfo: CoinPriceObj) {
   if (socket !== undefined) {
     socket.close()
   }

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -26,9 +26,7 @@ export default function Home() {
     data.map(coin => coin.name)
   ) //선택된 market 컨트롤
   const [selectedMarket, setSelectedMarket] = useState<string>('btc')
-  const [selectedSort, setSelectedSort] = useState<string>(
-    'market capitalization'
-  )
+  const [selectedSort, setSelectedSort] = useState<string>('change rate')
   const [selectedTab, setSelectedTab] = useState<number>(0)
   const [isDrawerOpened, setIsDrawerOpened] = useState<boolean>(false)
   const [isModalOpened, setIsModalOpened] = useState<boolean>(false)
@@ -39,7 +37,7 @@ export default function Home() {
     if (selectedChart === 'RunningChart') {
       setSelectedSort('descending')
     } else {
-      setSelectedSort('market capitalization')
+      setSelectedSort('change rate')
     }
   }, [selectedChart])
 

--- a/client/utils/chartManager.ts
+++ b/client/utils/chartManager.ts
@@ -69,12 +69,9 @@ export function getXAxisScale(
       makeDate(
         data[option.renderStartDataIndex].timestamp -
           DatePeriod[candlePeriod] * (option.renderCandleCount + 1) * 1000,
-        DatePeriod[candlePeriod]
+        candlePeriod
       ),
-      makeDate(
-        data[option.renderStartDataIndex].timestamp,
-        DatePeriod[candlePeriod]
-      )
+      makeDate(data[option.renderStartDataIndex].timestamp, candlePeriod)
     ])
     .range([
       chartAreaXsize - (option.renderCandleCount + 1) * option.candleWidth,

--- a/client/utils/chartManager.ts
+++ b/client/utils/chartManager.ts
@@ -26,6 +26,7 @@ import { makeDate } from './dateManager'
 import { blueColorScale, redColorScale } from '@/styles/colorScale'
 import { CoinRateContentType } from '@/types/ChartTypes'
 import { Dispatch, SetStateAction } from 'react'
+import { transDate } from '@/utils/dateManager'
 
 export function getVolumeHeightScale(
   data: CandleData[],
@@ -53,7 +54,11 @@ export function getYAxisScale(data: CandleData[], CHART_AREA_Y_SIZE: number) {
     console.error('데이터에 문제가 있다. 서버에서 잘못 쏨')
     return undefined
   }
-  return d3.scaleLinear().domain([min, max]).range([CHART_AREA_Y_SIZE, 0])
+  const diff = max - min
+  return d3
+    .scaleLinear()
+    .domain([min - 0.03 * diff, max + 0.03 * diff])
+    .range([CHART_AREA_Y_SIZE, 0])
 }
 
 // scale함수 updateChart에서만 호출
@@ -133,7 +138,8 @@ export function updatePointerUI(
   pointerInfo: PointerData,
   renderOpt: CandleChartRenderOption,
   data: CandleData[],
-  refElementSize: RefElementSize
+  refElementSize: RefElementSize,
+  period: ChartPeriod
 ) {
   const [chartAreaXsize, chartAreaYsize] = [
     refElementSize.width - CHART_Y_AXIS_MARGIN,
@@ -147,7 +153,8 @@ export function updatePointerUI(
     ),
     chartAreaYsize
   )
-  if (!yAxisScale) {
+  const xAxisScale = getXAxisScale(renderOpt, data, chartAreaXsize, period)
+  if (!yAxisScale || !xAxisScale) {
     return
   }
   d3.select('text#price-info')
@@ -210,6 +217,14 @@ export function updatePointerUI(
           )
           .text((d, i) => {
             if (i === 0) {
+              const unitData = pointerInfo.data
+              if (!unitData || !unitData.candle_date_time_kst) {
+                return getTimeTextByPosX(
+                  pointerInfo.positionX,
+                  xAxisScale,
+                  period
+                )
+              }
               return getTimeText(pointerInfo.data)
             }
             return Math.round(yAxisScale.invert(d)).toLocaleString()
@@ -269,17 +284,30 @@ function getTimeText(unitData: CandleData | null) {
   return `${timeString.substring(5, 10)} ${timeString.substring(11, 16)}`
 }
 
+function getTimeTextByPosX(
+  posX: number,
+  xAxisScale: d3.ScaleTime<number, number, never>,
+  period: ChartPeriod
+) {
+  const dateString = transDate(xAxisScale.invert(posX).getTime(), period)
+  return `${dateString.substring(5, 10)} ${dateString.substring(11, 16)}`
+}
+
 // 마우스 포인터가 가리키는 위치의 분봉데이터를 찾아 렌더링될 가격정보를 반환
 function getPriceInfo(pointerInfo: PointerData) {
   if (pointerInfo.positionX < 0) {
     return { priceText: '' }
   }
-  if (!pointerInfo.data) {
-    // console.error(pointerInfo)
-    // console.error('예외상황')
+  const candleUnitData = pointerInfo.data
+  if (
+    !candleUnitData ||
+    !candleUnitData.high_price ||
+    !candleUnitData.low_price ||
+    !candleUnitData.opening_price ||
+    !candleUnitData.trade_price
+  ) {
     return { priceText: '' }
   }
-  const candleUnitData = pointerInfo.data
   return {
     priceText: [
       `고가: ${candleUnitData.high_price}`,

--- a/client/utils/dateManager.ts
+++ b/client/utils/dateManager.ts
@@ -1,11 +1,20 @@
 import { ChartPeriod, DatePeriod } from '@/types/ChartTypes'
 
 export function transDate(timestamp: number, period: ChartPeriod): string {
-  const date = new Date(timestamp - (timestamp % (DatePeriod[period] * 1000)))
+  const date = makeDate(timestamp, period)
   date.setHours(date.getHours() + 9)
   return date.toISOString().substring(0, 19)
 }
 
-export function makeDate(timestamp: number, period: number): Date {
-  return new Date(timestamp - (timestamp % (period * 1000)))
+export function makeDate(timestamp: number, period: ChartPeriod): Date {
+  const date = new Date(timestamp - (timestamp % (DatePeriod[period] * 1000)))
+  if (period === 'weeks') {
+    const originalDate = new Date(timestamp)
+    if (originalDate.getUTCDay() < 4) {
+      date.setHours(105)
+    } else {
+      date.setHours(-63)
+    }
+  }
+  return date
 }


### PR DESCRIPTION
## 개요
- 실시간 코인 가격 정보 컴포넌트에서 이름명으로 정렬되지 않는 부분에 hover 이벤트 걸려있던 부분 수정
- 메인페이지 주기적으로 RestAPI로 데이터 요청하는 부분 소켓을 통해 데이터 받아오도록 수정
- 캔들차트 weeks 차트에서 주봉이 이상하게 렌더링되는 부분 수정
- 캔들차트 데이터가 없을때 마우스 포인터가 가르키는 시간이 표시되지 않던 부분 수정
- 실시간 코인 가격정보 컴포넌트에서 주기적으로 가격이 변동된 코인들만 리렌더링 되도록 수정
- **더이상 백그라운드에 오래있으면 크롬이 먹통이 되지 않음!**

## 작업사항
- RestAPI로 데이터 요청하던 부분 소켓을 통해 데이터를 받아오고 주기적으로 상태에 반영하도록 수정
- timestamp로 날짜를 계산하는 부분 weeks의 경우 완벽하게 들어맞지 않았던 부분이 있어 weeks일 경우에만 계산방식 변경
- 마우스 포인터가 가르키는 시간대에 거래데이터가 없으면 xAxisScale과 마우스의 x좌표를 이용하여 시간을 계산하도록 수정
- memo를 활용하여 리렌더링이 필요없는 컴포넌트 리렌더링 안일어나도록 수정
- `visibilitychange` 이벤트 활용해 백그라운드에서 JS 실행하지 않도록 수정

## 이미지

![Dec-15-2022 01-55-19](https://user-images.githubusercontent.com/70005144/207691358-abe902e3-1a9f-476b-8b45-8073192c2efa.gif)
![Dec-15-2022 00-24-20](https://user-images.githubusercontent.com/70005144/207691411-744515bb-566f-4013-b8c0-ae92ffe86f49.gif)
